### PR TITLE
Fix the haproxy 1.5 libpcpre3 dependency.

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:wheezy
 
+RUN apt-get update && apt-get install -y libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 ENV HAPROXY_MAJOR 1.4
 ENV HAPROXY_VERSION 1.4.26
 ENV HAPROXY_MD5 0606180bb01d9b91b49e6ca16e681172

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:wheezy
 
-RUN apt-get update && apt-get install -y libssl1.0.0 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.0.0 libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.5
 ENV HAPROXY_VERSION 1.5.11


### PR DESCRIPTION
haproxy 1.5 has a run time dependency on libpcre3 and therefore
the libraries should be installed independently of the build
dependencies.