### PR TITLE
fix issue of missing pcre library

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -4,6 +4,9 @@ ENV HAPROXY_MAJOR 1.4
 ENV HAPROXY_VERSION 1.4.26
 ENV HAPROXY_MD5 0606180bb01d9b91b49e6ca16e681172
 
+# install runtime dependencies so 'apt-get purge --auto-remove' doesn't remove them when $buildDeps is cleaned up
+RUN apt-get update && apt-get install -y libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
 	&& set -x \

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,10 +1,11 @@
 FROM debian:wheezy
 
-RUN apt-get update && apt-get install -y libssl1.0.0 --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
 ENV HAPROXY_MAJOR 1.5
 ENV HAPROXY_VERSION 1.5.11
 ENV HAPROXY_MD5 5500a79d0d2b238d4a1e9749bd0c2cb2
+
+# install runtime dependencies so 'apt-get purge --auto-remove' doesn't remove them when $buildDeps is cleaned up
+RUN apt-get update && apt-get install -y libpcre3 libssl1.0.0 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \


### PR DESCRIPTION
fix issue of missing pcre library by explicitly installing the runtime dependency so that they're not removed later when buildDeps are cleaned up via 'apt-get purge --auto-remove'