### PR TITLE
Add 1.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: bash
 sudo: 9000
 
 env:
+  - VERSION=1.6
   - VERSION=1.5
   - VERSION=1.4
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:wheezy
+
+RUN apt-get update && apt-get install -y libssl1.0.0 libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV HAPROXY_MAJOR 1.6
+ENV HAPROXY_VERSION 1.6.1
+ENV HAPROXY_MD5 7343def2af8556ebc8972a9748176094
+
+# see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
+	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	&& make -C /usr/src/haproxy \
+		TARGET=linux2628 \
+		USE_PCRE=1 PCREDIR= \
+		USE_OPENSSL=1 \
+		USE_ZLIB=1 \
+		all \
+		install-bin \
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]


### PR DESCRIPTION
Add version 1.6.1, released 10/20/2015.  Release notes: http://www.haproxy.org/download/1.6/src/CHANGELOG