### PR TITLE
Add reload support

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -27,4 +27,6 @@ RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
 	&& rm -rf /usr/src/haproxy \
 	&& apt-get purge -y --auto-remove $buildDeps
 
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/1.4/docker-entrypoint.sh
+++ b/1.4/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1:0:1}" = '-' ]; then
+	set -- haproxy "$@"
+fi
+
+exec "$@"

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -27,4 +27,6 @@ RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
 	&& rm -rf /usr/src/haproxy \
 	&& apt-get purge -y --auto-remove $buildDeps
 
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/1.5/docker-entrypoint.sh
+++ b/1.5/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1:0:1}" = '-' ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	# if the user wants "haproxy", let's use "haproxy-systemd-wrapper" instead so we can have proper reloadability implemented by upstream
+	shift # "haproxy"
+	set -- "$(which haproxy-systemd-wrapper)" -p /run/haproxy.pid "$@"
+fi
+
+exec "$@"

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -27,4 +27,6 @@ RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
 	&& rm -rf /usr/src/haproxy \
 	&& apt-get purge -y --auto-remove $buildDeps
 
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/1.6/docker-entrypoint.sh
+++ b/1.6/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eo pipefail
+
+# first arg is `-f` or `--some-option`
+if [ "${1:0:1}" = '-' ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	# if the user wants "haproxy", let's use "haproxy-systemd-wrapper" instead so we can have proper reloadability implemented by upstream
+	shift # "haproxy"
+	set -- "$(which haproxy-systemd-wrapper)" -p /run/haproxy.pid "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
I have only tested 1.6 and only slightly.

Reload like `docker kill --signal=USR2 <container>` or HUP

Full path and pid is required for haporxy-systemd-wrapper to work.
Fix #5