### PR TITLE
Add haproxy 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: bash
 services: docker
 
 env:
+  - VERSION=1.7 VARIANT=
+  - VERSION=1.7 VARIANT=alpine
   - VERSION=1.6 VARIANT=
   - VERSION=1.6 VARIANT=alpine
   - VERSION=1.5 VARIANT=

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y libssl1.0.0 libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ENV HAPROXY_MAJOR 1.7
+ENV HAPROXY_VERSION 1.7.0
+ENV HAPROXY_MD5 ab6e169aeb1b53364aacda80c904398a
+
+# see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
+	&& set -x \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
+	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	&& make -C /usr/src/haproxy \
+		TARGET=linux2628 \
+		USE_PCRE=1 PCREDIR= \
+		USE_OPENSSL=1 \
+		USE_ZLIB=1 \
+		all \
+		install-bin \
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	&& apt-get purge -y --auto-remove $buildDeps
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.4
+
+ENV HAPROXY_MAJOR 1.7
+ENV HAPROXY_VERSION 1.7.0
+ENV HAPROXY_MD5 ab6e169aeb1b53364aacda80c904398a
+
+# see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	&& apk add --no-cache --virtual .build-deps \
+		curl \
+		gcc \
+		libc-dev \
+		linux-headers \
+		make \
+		openssl-dev \
+		pcre-dev \
+		zlib-dev \
+	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
+	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src \
+	&& tar -xzf haproxy.tar.gz -C /usr/src \
+	&& mv "/usr/src/haproxy-$HAPROXY_VERSION" /usr/src/haproxy \
+	&& rm haproxy.tar.gz \
+	&& make -C /usr/src/haproxy \
+		TARGET=linux2628 \
+		USE_PCRE=1 PCREDIR= \
+		USE_OPENSSL=1 \
+		USE_ZLIB=1 \
+		all \
+		install-bin \
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)" \
+	&& apk add --virtual .haproxy-rundeps $runDeps \
+	&& apk del .build-deps
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/1.7/alpine/docker-entrypoint.sh
+++ b/1.7/alpine/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	# if the user wants "haproxy", let's use "haproxy-systemd-wrapper" instead so we can have proper reloadability implemented by upstream
+	shift # "haproxy"
+	set -- "$(which haproxy-systemd-wrapper)" -p /run/haproxy.pid "$@"
+fi
+
+exec "$@"

--- a/1.7/docker-entrypoint.sh
+++ b/1.7/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	# if the user wants "haproxy", let's use "haproxy-systemd-wrapper" instead so we can have proper reloadability implemented by upstream
+	shift # "haproxy"
+	set -- "$(which haproxy-systemd-wrapper)" -p /run/haproxy.pid "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Closes docker-library/haproxy#34

```
[timwolla@/s/D/o/haproxy (1.7)]diff -Nur 1.6 1.7                                                                                                                                                            16:35:06
diff -Nur 1.6/alpine/Dockerfile 1.7/alpine/Dockerfile
--- 1.6/alpine/Dockerfile	2016-11-27 16:34:19.693358288 +0100
+++ 1.7/alpine/Dockerfile	2016-11-27 16:34:20.177366698 +0100
@@ -1,8 +1,8 @@
 FROM alpine:3.4
 
-ENV HAPROXY_MAJOR 1.6
-ENV HAPROXY_VERSION 1.6.10
-ENV HAPROXY_MD5 6d47461c008b823a0088d19ec30dbe4e
+ENV HAPROXY_MAJOR 1.7
+ENV HAPROXY_VERSION 1.7.0
+ENV HAPROXY_MD5 ab6e169aeb1b53364aacda80c904398a
 
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
diff -Nur 1.6/Dockerfile 1.7/Dockerfile
--- 1.6/Dockerfile	2016-11-27 16:34:19.685358149 +0100
+++ 1.7/Dockerfile	2016-11-27 16:34:56.305985433 +0100
@@ -2,9 +2,9 @@
 
 RUN apt-get update && apt-get install -y libssl1.0.0 libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-ENV HAPROXY_MAJOR 1.6
-ENV HAPROXY_VERSION 1.6.10
-ENV HAPROXY_MD5 6d47461c008b823a0088d19ec30dbe4e
+ENV HAPROXY_MAJOR 1.7
+ENV HAPROXY_VERSION 1.7.0
+ENV HAPROXY_MD5 ab6e169aeb1b53364aacda80c904398a
 
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
```