### PR TITLE
Add lua support.

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,13 +1,15 @@
-FROM debian:jessie
+FROM debian:jessie-backports
 
-RUN apt-get update && apt-get install -y libssl1.0.0 libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+	&& apt-get install -y libssl1.0.0 libpcre3 lua5.3 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.6
 ENV HAPROXY_VERSION 1.6.11
 ENV HAPROXY_MD5 844da4b553c887833550a008692e7a74
 
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
-RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
+RUN buildDeps='curl gcc libc6-dev liblua5.3-dev libpcre3-dev libssl-dev make' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
@@ -19,6 +21,7 @@ RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
 		TARGET=linux2628 \
 		USE_PCRE=1 PCREDIR= \
 		USE_OPENSSL=1 \
+		USE_LUA=1 \
 		USE_ZLIB=1 \
 		all \
 		install-bin \

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,33 +1,50 @@
 FROM debian:jessie-backports
 
 RUN apt-get update \
-	&& apt-get install -y libssl1.0.0 libpcre3 lua5.3 --no-install-recommends \
+	&& apt-get install -y --no-install-recommends \
+		liblua5.3-0 \
+		libpcre3 \
+		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.6
 ENV HAPROXY_VERSION 1.6.11
 ENV HAPROXY_MD5 844da4b553c887833550a008692e7a74
 
-# see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
-RUN buildDeps='curl gcc libc6-dev liblua5.3-dev libpcre3-dev libssl-dev make' \
-	&& set -x \
+# see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& buildDeps=' \
+		gcc \
+		libc6-dev \
+		liblua5.3-dev \
+		libpcre3-dev \
+		libssl-dev \
+		make \
+		wget \
+	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
-	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
+	\
+	&& wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
 	&& mkdir -p /usr/src/haproxy \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
-	&& make -C /usr/src/haproxy \
+	\
+	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_PCRE=1 PCREDIR= \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_OPENSSL=1 \
-		USE_LUA=1 \
+		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
-		all \
-		install-bin \
+	' \
+	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
 	&& rm -rf /usr/src/haproxy \
+	\
 	&& apt-get purge -y --auto-remove $buildDeps
 
 COPY docker-entrypoint.sh /

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -3,49 +3,69 @@ FROM alpine:3.5
 ENV HAPROXY_MAJOR 1.6
 ENV HAPROXY_VERSION 1.6.11
 ENV HAPROXY_MD5 844da4b553c887833550a008692e7a74
-ENV LUA_MAJOR=5.3 \
-	LUA_VERSION=5.3.3 \
-	LUA_MD5=703f75caa4fdf4a911c1a72e67a27498
 
-# see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
+# https://www.lua.org/ftp/#source
+ENV LUA_VERSION=5.3.3 \
+	LUA_SHA1=a0341bc3d1415b814cc738b2ec01ae56045d64ef
+
+# see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
+	\
 	&& apk add --no-cache --virtual .build-deps \
-		curl \
+		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \
 		make \
+		openssl \
 		openssl-dev \
 		pcre-dev \
 		readline-dev \
+		tar \
 		zlib-dev \
-
-	# Install Lua
-	&& curl -SLR https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz -o lua.tar.gz \
-	&& echo "$LUA_MD5  lua.tar.gz" | md5sum -c \
-	&& mkdir -p /usr/src \
-	&& tar -xzf lua.tar.gz -C /usr/src \
-	&& mv "/usr/src/lua-$LUA_VERSION" /usr/src/lua \
+	\
+# install Lua
+	&& wget -O lua.tar.gz "https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz" \
+	&& echo "$LUA_SHA1 *lua.tar.gz" | sha1sum -c \
+	&& mkdir -p /usr/src/lua \
+	&& tar -xzf lua.tar.gz -C /usr/src/lua --strip-components=1 \
 	&& rm lua.tar.gz \
-	&& make -C /usr/src/lua linux install \
-
-	# Install HAProxy
-	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
-	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
-	&& tar -xzf haproxy.tar.gz -C /usr/src \
-	&& mv "/usr/src/haproxy-$HAPROXY_VERSION" /usr/src/haproxy \
+	&& make -C /usr/src/lua -j "$(getconf _NPROCESSORS_ONLN)" linux \
+	&& make -C /usr/src/lua install \
+# put things we don't care about into a "trash" directory for purging
+		INSTALL_BIN='/usr/src/lua/trash/bin' \
+		INSTALL_CMOD='/usr/src/lua/trash/cmod' \
+		INSTALL_LMOD='/usr/src/lua/trash/lmod' \
+		INSTALL_MAN='/usr/src/lua/trash/man' \
+# ... and since it builds static by default, put those bits somewhere we can purge after we build haproxy
+		INSTALL_INC='/usr/local/lua-install/inc' \
+		INSTALL_LIB='/usr/local/lua-install/lib' \
+	&& rm -rf /usr/src/lua \
+	\
+# install HAProxy
+	&& wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
-	&& make -C /usr/src/haproxy \
+	\
+	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_PCRE=1 PCREDIR= \
+		USE_LUA=1 LUA_INC=/usr/local/lua-install/inc LUA_LIB=/usr/local/lua-install/lib \
 		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
-		USE_LUA=1 \
-		all \
-		install-bin \
+	' \
+	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+# purge the remnants of our static Lua
+	&& rm -rf /usr/local/lua-install \
+	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
 	&& rm -rf /usr/src/haproxy \
+	\
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.5
 ENV HAPROXY_MAJOR 1.6
 ENV HAPROXY_VERSION 1.6.11
 ENV HAPROXY_MD5 844da4b553c887833550a008692e7a74
+ENV LUA_MAJOR=5.3 \
+	LUA_VERSION=5.3.3 \
+	LUA_MD5=703f75caa4fdf4a911c1a72e67a27498
 
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
@@ -14,10 +17,21 @@ RUN set -x \
 		make \
 		openssl-dev \
 		pcre-dev \
+		readline-dev \
 		zlib-dev \
+
+	# Install Lua
+	&& curl -SLR https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz -o lua.tar.gz \
+	&& echo "$LUA_MD5  lua.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src \
+	&& tar -xzf lua.tar.gz -C /usr/src \
+	&& mv "/usr/src/lua-$LUA_VERSION" /usr/src/lua \
+	&& rm lua.tar.gz \
+	&& make -C /usr/src/lua linux install \
+
+	# Install HAProxy
 	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
 	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
-	&& mkdir -p /usr/src \
 	&& tar -xzf haproxy.tar.gz -C /usr/src \
 	&& mv "/usr/src/haproxy-$HAPROXY_VERSION" /usr/src/haproxy \
 	&& rm haproxy.tar.gz \
@@ -26,6 +40,7 @@ RUN set -x \
 		USE_PCRE=1 PCREDIR= \
 		USE_OPENSSL=1 \
 		USE_ZLIB=1 \
+		USE_LUA=1 \
 		all \
 		install-bin \
 	&& mkdir -p /usr/local/etc/haproxy \

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,13 +1,15 @@
-FROM debian:jessie
+FROM debian:jessie-backports
 
-RUN apt-get update && apt-get install -y libssl1.0.0 libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+	&& apt-get install -y libssl1.0.0 libpcre3 lua5.3 --no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.7
 ENV HAPROXY_VERSION 1.7.2
 ENV HAPROXY_MD5 7330b36f3764ebe409e9305803dc30e2
 
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
-RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
+RUN buildDeps='curl gcc libc6-dev liblua5.3-dev libpcre3-dev libssl-dev make' \
 	&& set -x \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
@@ -19,6 +21,7 @@ RUN buildDeps='curl gcc libc6-dev libpcre3-dev libssl-dev make' \
 		TARGET=linux2628 \
 		USE_PCRE=1 PCREDIR= \
 		USE_OPENSSL=1 \
+		USE_LUA=1 \
 		USE_ZLIB=1 \
 		all \
 		install-bin \

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,33 +1,50 @@
 FROM debian:jessie-backports
 
 RUN apt-get update \
-	&& apt-get install -y libssl1.0.0 libpcre3 lua5.3 --no-install-recommends \
+	&& apt-get install -y --no-install-recommends \
+		liblua5.3-0 \
+		libpcre3 \
+		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.7
 ENV HAPROXY_VERSION 1.7.2
 ENV HAPROXY_MD5 7330b36f3764ebe409e9305803dc30e2
 
-# see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
-RUN buildDeps='curl gcc libc6-dev liblua5.3-dev libpcre3-dev libssl-dev make' \
-	&& set -x \
+# see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& buildDeps=' \
+		gcc \
+		libc6-dev \
+		liblua5.3-dev \
+		libpcre3-dev \
+		libssl-dev \
+		make \
+		wget \
+	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
-	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
+	\
+	&& wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
 	&& mkdir -p /usr/src/haproxy \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
-	&& make -C /usr/src/haproxy \
+	\
+	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_PCRE=1 PCREDIR= \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_OPENSSL=1 \
-		USE_LUA=1 \
+		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
-		all \
-		install-bin \
+	' \
+	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
 	&& rm -rf /usr/src/haproxy \
+	\
 	&& apt-get purge -y --auto-remove $buildDeps
 
 COPY docker-entrypoint.sh /

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -3,6 +3,9 @@ FROM alpine:3.5
 ENV HAPROXY_MAJOR 1.7
 ENV HAPROXY_VERSION 1.7.2
 ENV HAPROXY_MD5 7330b36f3764ebe409e9305803dc30e2
+ENV LUA_MAJOR=5.3 \
+	LUA_VERSION=5.3.3 \
+	LUA_MD5=703f75caa4fdf4a911c1a72e67a27498
 
 # see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
@@ -14,7 +17,19 @@ RUN set -x \
 		make \
 		openssl-dev \
 		pcre-dev \
+		readline-dev \
 		zlib-dev \
+
+	# Install Lua
+	&& curl -SLR https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz -o lua.tar.gz \
+	&& echo "$LUA_MD5  lua.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src \
+	&& tar -xzf lua.tar.gz -C /usr/src \
+	&& mv "/usr/src/lua-$LUA_VERSION" /usr/src/lua \
+	&& rm lua.tar.gz \
+	&& make -C /usr/src/lua linux install \
+
+	# Install HAProxy
 	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
 	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
 	&& mkdir -p /usr/src \
@@ -26,6 +41,7 @@ RUN set -x \
 		USE_PCRE=1 PCREDIR= \
 		USE_OPENSSL=1 \
 		USE_ZLIB=1 \
+		USE_LUA=1 \
 		all \
 		install-bin \
 	&& mkdir -p /usr/local/etc/haproxy \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -3,50 +3,69 @@ FROM alpine:3.5
 ENV HAPROXY_MAJOR 1.7
 ENV HAPROXY_VERSION 1.7.2
 ENV HAPROXY_MD5 7330b36f3764ebe409e9305803dc30e2
-ENV LUA_MAJOR=5.3 \
-	LUA_VERSION=5.3.3 \
-	LUA_MD5=703f75caa4fdf4a911c1a72e67a27498
 
-# see http://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
+# https://www.lua.org/ftp/#source
+ENV LUA_VERSION=5.3.3 \
+	LUA_SHA1=a0341bc3d1415b814cc738b2ec01ae56045d64ef
+
+# see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
+	\
 	&& apk add --no-cache --virtual .build-deps \
-		curl \
+		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \
 		make \
+		openssl \
 		openssl-dev \
 		pcre-dev \
 		readline-dev \
+		tar \
 		zlib-dev \
-
-	# Install Lua
-	&& curl -SLR https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz -o lua.tar.gz \
-	&& echo "$LUA_MD5  lua.tar.gz" | md5sum -c \
-	&& mkdir -p /usr/src \
-	&& tar -xzf lua.tar.gz -C /usr/src \
-	&& mv "/usr/src/lua-$LUA_VERSION" /usr/src/lua \
+	\
+# install Lua
+	&& wget -O lua.tar.gz "https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz" \
+	&& echo "$LUA_SHA1 *lua.tar.gz" | sha1sum -c \
+	&& mkdir -p /usr/src/lua \
+	&& tar -xzf lua.tar.gz -C /usr/src/lua --strip-components=1 \
 	&& rm lua.tar.gz \
-	&& make -C /usr/src/lua linux install \
-
-	# Install HAProxy
-	&& curl -SL "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
-	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
-	&& mkdir -p /usr/src \
-	&& tar -xzf haproxy.tar.gz -C /usr/src \
-	&& mv "/usr/src/haproxy-$HAPROXY_VERSION" /usr/src/haproxy \
+	&& make -C /usr/src/lua -j "$(getconf _NPROCESSORS_ONLN)" linux \
+	&& make -C /usr/src/lua install \
+# put things we don't care about into a "trash" directory for purging
+		INSTALL_BIN='/usr/src/lua/trash/bin' \
+		INSTALL_CMOD='/usr/src/lua/trash/cmod' \
+		INSTALL_LMOD='/usr/src/lua/trash/lmod' \
+		INSTALL_MAN='/usr/src/lua/trash/man' \
+# ... and since it builds static by default, put those bits somewhere we can purge after we build haproxy
+		INSTALL_INC='/usr/local/lua-install/inc' \
+		INSTALL_LIB='/usr/local/lua-install/lib' \
+	&& rm -rf /usr/src/lua \
+	\
+# install HAProxy
+	&& wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
-	&& make -C /usr/src/haproxy \
+	\
+	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_PCRE=1 PCREDIR= \
+		USE_LUA=1 LUA_INC=/usr/local/lua-install/inc LUA_LIB=/usr/local/lua-install/lib \
 		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
-		USE_LUA=1 \
-		all \
-		install-bin \
+	' \
+	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+# purge the remnants of our static Lua
+	&& rm -rf /usr/local/lua-install \
+	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
 	&& rm -rf /usr/src/haproxy \
+	\
 	&& runDeps="$( \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \


### PR DESCRIPTION
Following https://github.com/docker-library/haproxy/issues/28#issuecomment-268682953, there you have Lua support for 1.6+.

[It must be Lua >= 5.3, so I cannot use system packages for now](http://blog.haproxy.com/2015/10/14/whats-new-in-haproxy-1-6/). Debian and Alpine have older packaged versions.

@Tecnativa