### PR TITLE
Add haproxy 1.8-rc4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: bash
 services: docker
 
 env:
+  - VERSION=1.8-rc VARIANT=
+  - VERSION=1.8-rc ARCH=i386
+  - VERSION=1.8-rc VARIANT=alpine
   - VERSION=1.7 VARIANT=
   - VERSION=1.7 ARCH=i386
   - VERSION=1.7 VARIANT=alpine

--- a/1.8-rc/Dockerfile
+++ b/1.8-rc/Dockerfile
@@ -1,0 +1,53 @@
+FROM debian:stretch
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		liblua5.3-0 \
+		libpcre3 \
+		libssl1.1 \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV HAPROXY_MAJOR 1.8
+ENV HAPROXY_VERSION 1.8-rc4
+ENV HAPROXY_MD5 9bf5e689ceda1e5c8ec137042b2b1549
+
+# see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& buildDeps=' \
+		gcc \
+		libc6-dev \
+		liblua5.3-dev \
+		libpcre3-dev \
+		libssl-dev \
+		zlib1g-dev \
+		make \
+		wget \
+	' \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux2628 \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
+		USE_ZLIB=1 \
+	' \
+	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& apt-get purge -y --auto-remove $buildDeps
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-W", "-f", "/usr/local/etc/haproxy/"]

--- a/1.8-rc/Dockerfile
+++ b/1.8-rc/Dockerfile
@@ -50,4 +50,4 @@ RUN set -x \
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["haproxy", "-W", "-f", "/usr/local/etc/haproxy/"]
+CMD ["haproxy", "-W", "-db", "-f", "/usr/local/etc/haproxy/"]

--- a/1.8-rc/alpine/Dockerfile
+++ b/1.8-rc/alpine/Dockerfile
@@ -1,0 +1,80 @@
+FROM alpine:3.6
+
+ENV HAPROXY_MAJOR 1.8
+ENV HAPROXY_VERSION 1.8-rc4
+ENV HAPROXY_MD5 9bf5e689ceda1e5c8ec137042b2b1549
+
+# https://www.lua.org/ftp/#source
+ENV LUA_VERSION=5.3.3 \
+	LUA_SHA1=a0341bc3d1415b814cc738b2ec01ae56045d64ef
+
+# see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& apk add --no-cache --virtual .build-deps \
+		ca-certificates \
+		gcc \
+		libc-dev \
+		linux-headers \
+		make \
+		openssl \
+		openssl-dev \
+		pcre-dev \
+		readline-dev \
+		tar \
+		zlib-dev \
+	\
+# install Lua
+	&& wget -O lua.tar.gz "https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz" \
+	&& echo "$LUA_SHA1 *lua.tar.gz" | sha1sum -c \
+	&& mkdir -p /usr/src/lua \
+	&& tar -xzf lua.tar.gz -C /usr/src/lua --strip-components=1 \
+	&& rm lua.tar.gz \
+	&& make -C /usr/src/lua -j "$(getconf _NPROCESSORS_ONLN)" linux \
+	&& make -C /usr/src/lua install \
+# put things we don't care about into a "trash" directory for purging
+		INSTALL_BIN='/usr/src/lua/trash/bin' \
+		INSTALL_CMOD='/usr/src/lua/trash/cmod' \
+		INSTALL_LMOD='/usr/src/lua/trash/lmod' \
+		INSTALL_MAN='/usr/src/lua/trash/man' \
+# ... and since it builds static by default, put those bits somewhere we can purge after we build haproxy
+		INSTALL_INC='/usr/local/lua-install/inc' \
+		INSTALL_LIB='/usr/local/lua-install/lib' \
+	&& rm -rf /usr/src/lua \
+	\
+# install HAProxy
+	&& wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux2628 \
+		USE_LUA=1 LUA_INC=/usr/local/lua-install/inc LUA_LIB=/usr/local/lua-install/lib \
+		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
+		USE_ZLIB=1 \
+	' \
+	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+# purge the remnants of our static Lua
+	&& rm -rf /usr/local/lua-install \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& apk add --virtual .haproxy-rundeps $runDeps \
+	&& apk del .build-deps
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-W", "-f", "/usr/local/etc/haproxy/"]

--- a/1.8-rc/alpine/Dockerfile
+++ b/1.8-rc/alpine/Dockerfile
@@ -77,4 +77,4 @@ RUN set -x \
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["haproxy", "-W", "-f", "/usr/local/etc/haproxy/"]
+CMD ["haproxy", "-W", "-db", "-f", "/usr/local/etc/haproxy/"]

--- a/1.8-rc/alpine/docker-entrypoint.sh
+++ b/1.8-rc/alpine/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+exec "$@"

--- a/1.8-rc/docker-entrypoint.sh
+++ b/1.8-rc/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+exec "$@"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,6 +3,7 @@ set -eu
 
 declare -A aliases=(
 	[1.7]='1 latest'
+	[1.8-rc]='rc'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Closes docker-library/haproxy#48

haproxy 1.8-rc4 is the first version I found stable enough for use inside of a Docker container. This pull request implements my suggestions I made on #48:

- Switch to Debian Stretch and Alpine 3.6
- Replace systemd-wrapper by master-worker-mode (`-W`)

I verified that reloading haproxy works fine in master-worker mode.

According to [Willy on the mailing list](https://www.mail-archive.com/haproxy@formilux.org/msg27884.html) the final release is not too far off. I'm creating this pull request nonetheless for some early discussion of the changes I did.