### PR TITLE
Alpine: Update Lua to 5.3.4

### DIFF
--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -5,8 +5,8 @@ ENV HAPROXY_VERSION 1.6.13
 ENV HAPROXY_MD5 782947642c0c7983f73624d8d45e2321
 
 # https://www.lua.org/ftp/#source
-ENV LUA_VERSION=5.3.3 \
-	LUA_SHA1=a0341bc3d1415b814cc738b2ec01ae56045d64ef
+ENV LUA_VERSION=5.3.4 \
+	LUA_SHA1=79790cfd40e09ba796b01a571d4d63b52b1cd950
 
 # see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -5,8 +5,8 @@ ENV HAPROXY_VERSION 1.7.9
 ENV HAPROXY_MD5 a2bbbdd45ffe18d99cdcf26aa992f92d
 
 # https://www.lua.org/ftp/#source
-ENV LUA_VERSION=5.3.3 \
-	LUA_SHA1=a0341bc3d1415b814cc738b2ec01ae56045d64ef
+ENV LUA_VERSION=5.3.4 \
+	LUA_SHA1=79790cfd40e09ba796b01a571d4d63b52b1cd950
 
 # see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/1.8-rc/alpine/Dockerfile
+++ b/1.8-rc/alpine/Dockerfile
@@ -5,8 +5,8 @@ ENV HAPROXY_VERSION 1.8-rc4
 ENV HAPROXY_MD5 9bf5e689ceda1e5c8ec137042b2b1549
 
 # https://www.lua.org/ftp/#source
-ENV LUA_VERSION=5.3.3 \
-	LUA_SHA1=a0341bc3d1415b814cc738b2ec01ae56045d64ef
+ENV LUA_VERSION=5.3.4 \
+	LUA_SHA1=79790cfd40e09ba796b01a571d4d63b52b1cd950
 
 # see http://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \


### PR DESCRIPTION
Updating the Lua version _could_ be added to the update script... but I'm lazy and Lua doesn't release new versions very often currently.

(I can also update the update script but it'll take a little while before I have the time).