### PR TITLE
create dir /var/run/haproxy

### DIFF
--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 	\
 	&& wget -O haproxy.tar.gz "http://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
 	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
-	&& mkdir -p /usr/src/haproxy \
+	&& mkdir -p /usr/src/haproxy /var/run/haproxy \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
 	\


### PR DESCRIPTION
Mitigates this error:
~~~
[ALERT] 362/193044 (1) : Starting frontend GLOBAL: cannot bind UNIX socket [/var/run/haproxy/haproxy.sock]
~~~

Current workaround is for instance `docker run ... -w /var/run/haproxy ...`