### PR TITLE
Add templates and remove manual Lua install

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -20,9 +20,9 @@ RUN set -x \
 		libc6-dev \
 		libpcre3-dev \
 		libssl-dev \
-		zlib1g-dev \
 		make \
 		wget \
+		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,30 +1,50 @@
+# vim:set ft=dockerfile:
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y libssl1.0.0 libpcre3 --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		libpcre3 \
+		libssl1.0.0 \
+	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.5
 ENV HAPROXY_VERSION 1.5.19
 ENV HAPROXY_MD5 74d49316f00e1fd9859bcac84ab04b5c
 
-# see https://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
-RUN buildDeps='ca-certificates curl gcc libc6-dev libpcre3-dev libssl-dev make' \
-	&& set -x \
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& buildDeps=' \
+		ca-certificates \
+		gcc \
+		libc6-dev \
+		libpcre3-dev \
+		libssl-dev \
+		zlib1g-dev \
+		make \
+		wget \
+	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-	&& curl -SL "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
-	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
+	\
+	&& wget -O haproxy.tar.gz "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
 	&& mkdir -p /usr/src/haproxy \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
-	&& make -C /usr/src/haproxy \
+	\
+	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_PCRE=1 PCREDIR= \
 		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
-		all \
-		install-bin \
+	' \
+	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
 	&& rm -rf /usr/src/haproxy \
+	\
 	&& apt-get purge -y --auto-remove $buildDeps
 
 COPY docker-entrypoint.sh /

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -1,37 +1,46 @@
+# vim:set ft=dockerfile:
 FROM alpine:3.5
 
 ENV HAPROXY_MAJOR 1.5
 ENV HAPROXY_VERSION 1.5.19
 ENV HAPROXY_MD5 74d49316f00e1fd9859bcac84ab04b5c
 
-# see https://sources.debian.net/src/haproxy/1.5.8-1/debian/rules/ for some helpful navigation of the possible "make" arguments
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
+	\
 	&& apk add --no-cache --virtual .build-deps \
 		ca-certificates \
-		curl \
 		gcc \
 		libc-dev \
 		linux-headers \
 		make \
+		openssl \
 		openssl-dev \
 		pcre-dev \
+		readline-dev \
+		tar \
 		zlib-dev \
-	&& curl -SL "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" -o haproxy.tar.gz \
-	&& echo "${HAPROXY_MD5}  haproxy.tar.gz" | md5sum -c \
-	&& mkdir -p /usr/src \
-	&& tar -xzf haproxy.tar.gz -C /usr/src \
-	&& mv "/usr/src/haproxy-$HAPROXY_VERSION" /usr/src/haproxy \
+	\
+# install HAProxy
+	&& wget -O haproxy.tar.gz "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
-	&& make -C /usr/src/haproxy \
+	\
+	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_PCRE=1 PCREDIR= \
 		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
-		all \
-		install-bin \
+	' \
+	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
 	&& rm -rf /usr/src/haproxy \
+	\
 	&& runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -22,9 +22,9 @@ RUN set -x \
 		liblua5.3-dev \
 		libpcre3-dev \
 		libssl-dev \
-		zlib1g-dev \
 		make \
 		wget \
+		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,11 +1,11 @@
 # vim:set ft=dockerfile:
-FROM debian:stretch-slim
+FROM debian:jessie-backports
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		liblua5.3-0 \
 		libpcre3 \
-		libssl1.1 \
+		libssl1.0.0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.6

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:jessie-backports
+# vim:set ft=dockerfile:
+FROM debian:stretch-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		liblua5.3-0 \
 		libpcre3 \
-		libssl1.0.0 \
+		libssl1.1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.6
@@ -21,6 +22,7 @@ RUN set -x \
 		liblua5.3-dev \
 		libpcre3-dev \
 		libssl-dev \
+		zlib1g-dev \
 		make \
 		wget \
 	' \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -1,12 +1,9 @@
-FROM alpine:3.5
+# vim:set ft=dockerfile:
+FROM alpine:3.7
 
 ENV HAPROXY_MAJOR 1.6
 ENV HAPROXY_VERSION 1.6.14
 ENV HAPROXY_MD5 5daf73eb70052e8ec66c40817f265202
-
-# https://www.lua.org/ftp/#source
-ENV LUA_VERSION=5.3.4 \
-	LUA_SHA1=79790cfd40e09ba796b01a571d4d63b52b1cd950
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
@@ -16,6 +13,7 @@ RUN set -x \
 		gcc \
 		libc-dev \
 		linux-headers \
+		lua5.3-dev \
 		make \
 		openssl \
 		openssl-dev \
@@ -23,24 +21,6 @@ RUN set -x \
 		readline-dev \
 		tar \
 		zlib-dev \
-	\
-# install Lua
-	&& wget -O lua.tar.gz "https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz" \
-	&& echo "$LUA_SHA1 *lua.tar.gz" | sha1sum -c \
-	&& mkdir -p /usr/src/lua \
-	&& tar -xzf lua.tar.gz -C /usr/src/lua --strip-components=1 \
-	&& rm lua.tar.gz \
-	&& make -C /usr/src/lua -j "$(getconf _NPROCESSORS_ONLN)" linux \
-	&& make -C /usr/src/lua install \
-# put things we don't care about into a "trash" directory for purging
-		INSTALL_BIN='/usr/src/lua/trash/bin' \
-		INSTALL_CMOD='/usr/src/lua/trash/cmod' \
-		INSTALL_LMOD='/usr/src/lua/trash/lmod' \
-		INSTALL_MAN='/usr/src/lua/trash/man' \
-# ... and since it builds static by default, put those bits somewhere we can purge after we build haproxy
-		INSTALL_INC='/usr/local/lua-install/inc' \
-		INSTALL_LIB='/usr/local/lua-install/lib' \
-	&& rm -rf /usr/src/lua \
 	\
 # install HAProxy
 	&& wget -O haproxy.tar.gz "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
@@ -51,16 +31,13 @@ RUN set -x \
 	\
 	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_LUA=1 LUA_INC=/usr/local/lua-install/inc LUA_LIB=/usr/local/lua-install/lib \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
 	&& make -C /usr/src/haproxy install-bin $makeOpts \
-	\
-# purge the remnants of our static Lua
-	&& rm -rf /usr/local/lua-install \
 	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -22,9 +22,9 @@ RUN set -x \
 		liblua5.3-dev \
 		libpcre3-dev \
 		libssl-dev \
-		zlib1g-dev \
 		make \
 		wget \
+		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:jessie-backports
+# vim:set ft=dockerfile:
+FROM debian:stretch-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		liblua5.3-0 \
 		libpcre3 \
-		libssl1.0.0 \
+		libssl1.1 \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV HAPROXY_MAJOR 1.7
@@ -21,6 +22,7 @@ RUN set -x \
 		liblua5.3-dev \
 		libpcre3-dev \
 		libssl-dev \
+		zlib1g-dev \
 		make \
 		wget \
 	' \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -1,12 +1,9 @@
-FROM alpine:3.5
+# vim:set ft=dockerfile:
+FROM alpine:3.7
 
 ENV HAPROXY_MAJOR 1.7
 ENV HAPROXY_VERSION 1.7.10
 ENV HAPROXY_MD5 a9b98a228660dee5ee65b62e3bd57822
-
-# https://www.lua.org/ftp/#source
-ENV LUA_VERSION=5.3.4 \
-	LUA_SHA1=79790cfd40e09ba796b01a571d4d63b52b1cd950
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
@@ -16,6 +13,7 @@ RUN set -x \
 		gcc \
 		libc-dev \
 		linux-headers \
+		lua5.3-dev \
 		make \
 		openssl \
 		openssl-dev \
@@ -23,24 +21,6 @@ RUN set -x \
 		readline-dev \
 		tar \
 		zlib-dev \
-	\
-# install Lua
-	&& wget -O lua.tar.gz "https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz" \
-	&& echo "$LUA_SHA1 *lua.tar.gz" | sha1sum -c \
-	&& mkdir -p /usr/src/lua \
-	&& tar -xzf lua.tar.gz -C /usr/src/lua --strip-components=1 \
-	&& rm lua.tar.gz \
-	&& make -C /usr/src/lua -j "$(getconf _NPROCESSORS_ONLN)" linux \
-	&& make -C /usr/src/lua install \
-# put things we don't care about into a "trash" directory for purging
-		INSTALL_BIN='/usr/src/lua/trash/bin' \
-		INSTALL_CMOD='/usr/src/lua/trash/cmod' \
-		INSTALL_LMOD='/usr/src/lua/trash/lmod' \
-		INSTALL_MAN='/usr/src/lua/trash/man' \
-# ... and since it builds static by default, put those bits somewhere we can purge after we build haproxy
-		INSTALL_INC='/usr/local/lua-install/inc' \
-		INSTALL_LIB='/usr/local/lua-install/lib' \
-	&& rm -rf /usr/src/lua \
 	\
 # install HAProxy
 	&& wget -O haproxy.tar.gz "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
@@ -51,16 +31,13 @@ RUN set -x \
 	\
 	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_LUA=1 LUA_INC=/usr/local/lua-install/inc LUA_LIB=/usr/local/lua-install/lib \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
 	&& make -C /usr/src/haproxy install-bin $makeOpts \
-	\
-# purge the remnants of our static Lua
-	&& rm -rf /usr/local/lua-install \
 	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -22,9 +22,9 @@ RUN set -x \
 		liblua5.3-dev \
 		libpcre3-dev \
 		libssl-dev \
-		zlib1g-dev \
 		make \
 		wget \
+		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -1,3 +1,4 @@
+# vim:set ft=dockerfile:
 FROM debian:stretch-slim
 
 RUN apt-get update \

--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -1,12 +1,9 @@
-FROM alpine:3.6
+# vim:set ft=dockerfile:
+FROM alpine:3.7
 
 ENV HAPROXY_MAJOR 1.8
 ENV HAPROXY_VERSION 1.8.8
 ENV HAPROXY_MD5 8633b6e661169d2fc6a44d82a3aceae5
-
-# https://www.lua.org/ftp/#source
-ENV LUA_VERSION=5.3.4 \
-	LUA_SHA1=79790cfd40e09ba796b01a571d4d63b52b1cd950
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
@@ -16,6 +13,7 @@ RUN set -x \
 		gcc \
 		libc-dev \
 		linux-headers \
+		lua5.3-dev \
 		make \
 		openssl \
 		openssl-dev \
@@ -23,24 +21,6 @@ RUN set -x \
 		readline-dev \
 		tar \
 		zlib-dev \
-	\
-# install Lua
-	&& wget -O lua.tar.gz "https://www.lua.org/ftp/lua-$LUA_VERSION.tar.gz" \
-	&& echo "$LUA_SHA1 *lua.tar.gz" | sha1sum -c \
-	&& mkdir -p /usr/src/lua \
-	&& tar -xzf lua.tar.gz -C /usr/src/lua --strip-components=1 \
-	&& rm lua.tar.gz \
-	&& make -C /usr/src/lua -j "$(getconf _NPROCESSORS_ONLN)" linux \
-	&& make -C /usr/src/lua install \
-# put things we don't care about into a "trash" directory for purging
-		INSTALL_BIN='/usr/src/lua/trash/bin' \
-		INSTALL_CMOD='/usr/src/lua/trash/cmod' \
-		INSTALL_LMOD='/usr/src/lua/trash/lmod' \
-		INSTALL_MAN='/usr/src/lua/trash/man' \
-# ... and since it builds static by default, put those bits somewhere we can purge after we build haproxy
-		INSTALL_INC='/usr/local/lua-install/inc' \
-		INSTALL_LIB='/usr/local/lua-install/lib' \
-	&& rm -rf /usr/src/lua \
 	\
 # install HAProxy
 	&& wget -O haproxy.tar.gz "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
@@ -51,16 +31,13 @@ RUN set -x \
 	\
 	&& makeOpts=' \
 		TARGET=linux2628 \
-		USE_LUA=1 LUA_INC=/usr/local/lua-install/inc LUA_LIB=/usr/local/lua-install/lib \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
 	&& make -C /usr/src/haproxy install-bin $makeOpts \
-	\
-# purge the remnants of our static Lua
-	&& rm -rf /usr/local/lua-install \
 	\
 	&& mkdir -p /usr/local/etc/haproxy \
 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,0 +1,57 @@
+# vim:set ft=dockerfile:
+FROM alpine:%%ALPINE_VERSION%%
+
+ENV HAPROXY_MAJOR %%HAPROXY_MAJOR%%
+ENV HAPROXY_VERSION %%HAPROXY_VERSION%%
+ENV HAPROXY_MD5 %%HAPROXY_MD5%%
+
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& apk add --no-cache --virtual .build-deps \
+		ca-certificates \
+		gcc \
+		libc-dev \
+		linux-headers \
+		lua5.3-dev \
+		make \
+		openssl \
+		openssl-dev \
+		pcre-dev \
+		readline-dev \
+		tar \
+		zlib-dev \
+	\
+# install HAProxy
+	&& wget -O haproxy.tar.gz "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux2628 \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
+		USE_ZLIB=1 \
+	' \
+	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& apk add --virtual .haproxy-rundeps $runDeps \
+	&& apk del .build-deps
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -22,9 +22,9 @@ RUN set -x \
 		liblua5.3-dev \
 		libpcre3-dev \
 		libssl-dev \
-		zlib1g-dev \
 		make \
 		wget \
+		zlib1g-dev \
 	' \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,0 +1,55 @@
+# vim:set ft=dockerfile:
+FROM debian:%%DEBIAN_VERSION%%
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		liblua5.3-0 \
+		libpcre3 \
+		libssl1.1 \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV HAPROXY_MAJOR %%HAPROXY_MAJOR%%
+ENV HAPROXY_VERSION %%HAPROXY_VERSION%%
+ENV HAPROXY_MD5 %%HAPROXY_MD5%%
+
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& buildDeps=' \
+		ca-certificates \
+		gcc \
+		libc6-dev \
+		liblua5.3-dev \
+		libpcre3-dev \
+		libssl-dev \
+		zlib1g-dev \
+		make \
+		wget \
+	' \
+	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O haproxy.tar.gz "https://www.haproxy.org/download/${HAPROXY_MAJOR}/src/haproxy-${HAPROXY_VERSION}.tar.gz" \
+	&& echo "$HAPROXY_MD5 *haproxy.tar.gz" | md5sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux2628 \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
+		USE_ZLIB=1 \
+	' \
+	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& apt-get purge -y --auto-remove $buildDeps
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/update.sh
+++ b/update.sh
@@ -45,6 +45,13 @@ for version in "${versions[@]}"; do
 			s/%%HAPROXY_VERSION%%/'"$fullVersion"'/;
 			s/%%HAPROXY_MD5%%/'"$md5"'/;
 		'
+	
+	if [ "$version" = '1.5' ]; then
+		sedExpr+='
+			/lua/d;
+			s/libssl1.1/libssl1.0.0/;
+		'
+	fi
 	( set -x; sed -r "$sedExpr" 'Dockerfile-debian.template' > "$version/Dockerfile" )
 	
 	for variant in alpine; do
@@ -53,11 +60,6 @@ for version in "${versions[@]}"; do
 		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"
 	done
 
-	if [ "$version" = '1.5' ]; then
-		for dockerfile in "$version/Dockerfile" "$version/$variant/Dockerfile"; do
-			sed -ri -e '/lua/d' -e 's/libssl1.1/libssl1.0.0/' "$dockerfile"
-		done
-	fi
 
 	travisEnv='\n  - VERSION='"$version ARCH=i386$travisEnv"
 	travisEnv='\n  - VERSION='"$version VARIANT=$travisEnv"

--- a/update.sh
+++ b/update.sh
@@ -67,7 +67,6 @@ for version in "${versions[@]}"; do
 		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"
 	done
 
-
 	travisEnv='\n  - VERSION='"$version ARCH=i386$travisEnv"
 	travisEnv='\n  - VERSION='"$version VARIANT=$travisEnv"
 done

--- a/update.sh
+++ b/update.sh
@@ -9,6 +9,15 @@ if [ ${#versions[@]} -eq 0 ]; then
 fi
 versions=( "${versions[@]%/}" )
 
+defaultDebianSuite='stretch-slim'
+declare -A debianSuite=(
+	[1.5]='jessie'
+)
+defaultAlpineVersion='3.7'
+declare -A alpineVersion=(
+	[1.5]='3.5'
+)
+
 travisEnv=
 for version in "${versions[@]}"; do
 	rcGrepV='-v'
@@ -26,18 +35,30 @@ for version in "${versions[@]}"; do
 			| tail -1
 	)"
 	md5="$(curl -sSL --compressed 'https://www.haproxy.org/download/'"$rcVersion"'/src/haproxy-'"$fullVersion"'.tar.gz.md5' | cut -d' ' -f1)"
+
+	versionSuite="${debianSuite[$version]:-$defaultDebianSuite}"
+	alpine="${alpineVersion[$version]:-$defaultAlpineVersion}"
 	sedExpr='
-			s/^(ENV HAPROXY_MAJOR) .*/\1 '"$rcVersion"'/;
-			s/^(ENV HAPROXY_VERSION) .*/\1 '"$fullVersion"'/;
-			s/^(ENV HAPROXY_MD5) .*/\1 '"$md5"'/;
+			s/%%ALPINE_VERSION%%/'"$alpine"'/;
+			s/%%DEBIAN_VERSION%%/'"$versionSuite"'/;
+			s/%%HAPROXY_MAJOR%%/'"$rcVersion"'/;
+			s/%%HAPROXY_VERSION%%/'"$fullVersion"'/;
+			s/%%HAPROXY_MD5%%/'"$md5"'/;
 		'
-	( set -x; sed -ri "$sedExpr" "$version/Dockerfile" )
+	( set -x; sed -r "$sedExpr" 'Dockerfile-debian.template' > "$version/Dockerfile" )
 	
 	for variant in alpine; do
 		[ -d "$version/$variant" ] || continue
-		( set -x; sed -ri "$sedExpr" "$version/$variant/Dockerfile" )
+		( set -x; sed -r "$sedExpr" 'Dockerfile-alpine.template' > "$version/$variant/Dockerfile" )
 		travisEnv='\n  - VERSION='"$version VARIANT=$variant$travisEnv"
 	done
+
+	if [ "$version" = '1.5' ]; then
+		for dockerfile in "$version/Dockerfile" "$version/$variant/Dockerfile"; do
+			sed -ri -e '/lua/d' -e 's/libssl1.1/libssl1.0.0/' "$dockerfile"
+		done
+	fi
+
 	travisEnv='\n  - VERSION='"$version ARCH=i386$travisEnv"
 	travisEnv='\n  - VERSION='"$version VARIANT=$travisEnv"
 done

--- a/update.sh
+++ b/update.sh
@@ -11,6 +11,9 @@ versions=( "${versions[@]%/}" )
 
 defaultDebianSuite='stretch-slim'
 declare -A debianSuite=(
+# 1.6 does not support libssl1.1, which is the only libssl in stretch (backports gives us liblua)
+# https://git.haproxy.org/?p=haproxy-1.7.git;a=commitdiff;h=1866d6d8f1163fe28a1e8256080909a5aa166880
+	[1.6]='jessie-backports'
 	[1.5]='jessie'
 )
 defaultAlpineVersion='3.7'
@@ -49,6 +52,10 @@ for version in "${versions[@]}"; do
 	if [ "$version" = '1.5' ]; then
 		sedExpr+='
 			/lua/d;
+		'
+	fi
+	if [[ "$versionSuite" = jessie* ]]; then
+		sedExpr+='
 			s/libssl1.1/libssl1.0.0/;
 		'
 	fi


### PR DESCRIPTION
Fixes #61.

`1.5` should be materially unchanged. It'll be just the swap to `wget` and the explicit install of `zlib1g-dev` which was already assumed to be installed with `USE_ZLIB=1` (it is a dependency of `libssl-dev` in jessie but not stretch).