### PR TITLE
Add lts / edge tag

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,6 +3,7 @@ set -Eeuo pipefail
 
 declare -A aliases=(
 	[1.9]='1'
+	[2.0]='lts'
 	[2.1]='latest'
 )
 


### PR DESCRIPTION
The November releases of haproxy will only be supported for one year
starting with haproxy 1.9.

-----

see the “Quick News”: https://www.haproxy.org/#news

> An important point to note, this technical release is not suitable for inclusion in distros, as it will only be maintained for approximately one year (till 2.1 is out). Version 2.0 coming in May will be long-lived and more suitable for distros.

Making latest point to `1.9` makes sense nonetheless, as it's the first with logging to stdout.

It should also be evaluated whether the `haproxy:1` alias makes sense. The next version will be called 2.0 while not making any breaking changes to the best of my knowledge.