### PR TITLE
Add HAProxy 2.0-rc (2.0-dev3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: bash
 services: docker
 
 env:
+  - VERSION=2.0-rc VARIANT=
+  - VERSION=2.0-rc ARCH=i386
+  - VERSION=2.0-rc VARIANT=alpine
   - VERSION=1.9 VARIANT=
   - VERSION=1.9 ARCH=i386
   - VERSION=1.9 VARIANT=alpine

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x \
 	\
 	&& makeOpts=' \
 		TARGET=linux2628 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -29,6 +29,7 @@ RUN set -x \
 	\
 	&& makeOpts=' \
 		TARGET=linux2628 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -30,6 +30,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -30,6 +30,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -30,6 +30,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -30,6 +30,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/1.9/alpine/Dockerfile
+++ b/1.9/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/2.0-rc/Dockerfile
+++ b/2.0-rc/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM debian:stretch-slim
 
-ENV HAPROXY_VERSION 2.0-dev3
-ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/devel/haproxy-2.0-dev3.tar.gz
-ENV HAPROXY_SHA256 e871645a6293c0eba7b4e5b15be4988789ad7c20c46baf2ff86f7fb6487e120e
+ENV HAPROXY_VERSION 2.0-dev4
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/devel/haproxy-2.0-dev4.tar.gz
+ENV HAPROXY_SHA256 74680ccd42537fff2d54fa4c1658f203951b77836203e49bc30d65c1cae9767b
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/2.0-rc/Dockerfile
+++ b/2.0-rc/Dockerfile
@@ -30,6 +30,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/2.0-rc/Dockerfile
+++ b/2.0-rc/Dockerfile
@@ -1,0 +1,63 @@
+# vim:set ft=dockerfile:
+FROM debian:stretch-slim
+
+ENV HAPROXY_VERSION 2.0-dev3
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/devel/haproxy-2.0-dev3.tar.gz
+ENV HAPROXY_SHA256 e871645a6293c0eba7b4e5b15be4988789ad7c20c46baf2ff86f7fb6487e120e
+
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& savedAptMark="$(apt-mark showmanual)" \
+	&& apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
+		gcc \
+		libc6-dev \
+		liblua5.3-dev \
+		libpcre3-dev \
+		libssl-dev \
+		make \
+		wget \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O haproxy.tar.gz "$HAPROXY_URL" \
+	&& echo "$HAPROXY_SHA256 *haproxy.tar.gz" | sha256sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux2628 \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
+		USE_ZLIB=1 \
+	' \
+	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& apt-mark auto '.*' > /dev/null \
+	&& { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
+	&& find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+
+# https://www.haproxy.org/download/1.8/doc/management.txt
+# "4. Stopping and restarting HAProxy"
+# "when the SIGTERM signal is sent to the haproxy process, it immediately quits and all established connections are closed"
+# "graceful stop is triggered when the SIGUSR1 signal is sent to the haproxy process"
+STOPSIGNAL SIGUSR1
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.0-rc/alpine/Dockerfile
+++ b/2.0-rc/alpine/Dockerfile
@@ -1,0 +1,62 @@
+# vim:set ft=dockerfile:
+FROM alpine:3.9
+
+ENV HAPROXY_VERSION 2.0-dev3
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/devel/haproxy-2.0-dev3.tar.gz
+ENV HAPROXY_SHA256 e871645a6293c0eba7b4e5b15be4988789ad7c20c46baf2ff86f7fb6487e120e
+
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& apk add --no-cache --virtual .build-deps \
+		ca-certificates \
+		gcc \
+		libc-dev \
+		linux-headers \
+		lua5.3-dev \
+		make \
+		openssl \
+		openssl-dev \
+		pcre-dev \
+		readline-dev \
+		tar \
+		zlib-dev \
+	\
+	&& wget -O haproxy.tar.gz "$HAPROXY_URL" \
+	&& echo "$HAPROXY_SHA256 *haproxy.tar.gz" | sha256sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux2628 \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_OPENSSL=1 \
+		USE_PCRE=1 PCREDIR= \
+		USE_ZLIB=1 \
+	' \
+	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \
+	&& make -C /usr/src/haproxy install-bin $makeOpts \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& apk add --virtual .haproxy-rundeps $runDeps \
+	&& apk del .build-deps
+
+# https://www.haproxy.org/download/1.8/doc/management.txt
+# "4. Stopping and restarting HAProxy"
+# "when the SIGTERM signal is sent to the haproxy process, it immediately quits and all established connections are closed"
+# "graceful stop is triggered when the SIGUSR1 signal is sent to the haproxy process"
+STOPSIGNAL SIGUSR1
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.0-rc/alpine/Dockerfile
+++ b/2.0-rc/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/2.0-rc/alpine/Dockerfile
+++ b/2.0-rc/alpine/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM alpine:3.9
 
-ENV HAPROXY_VERSION 2.0-dev3
-ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/devel/haproxy-2.0-dev3.tar.gz
-ENV HAPROXY_SHA256 e871645a6293c0eba7b4e5b15be4988789ad7c20c46baf2ff86f7fb6487e120e
+ENV HAPROXY_VERSION 2.0-dev4
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/devel/haproxy-2.0-dev4.tar.gz
+ENV HAPROXY_SHA256 74680ccd42537fff2d54fa4c1658f203951b77836203e49bc30d65c1cae9767b
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/2.0-rc/alpine/docker-entrypoint.sh
+++ b/2.0-rc/alpine/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	shift # "haproxy"
+	# if the user wants "haproxy", let's add a couple useful flags
+	#   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
+	#   -db -- disables background mode
+	set -- haproxy -W -db "$@"
+fi
+
+exec "$@"

--- a/2.0-rc/docker-entrypoint.sh
+++ b/2.0-rc/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	shift # "haproxy"
+	# if the user wants "haproxy", let's add a couple useful flags
+	#   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
+	#   -db -- disables background mode
+	set -- haproxy -W -db "$@"
+fi
+
+exec "$@"

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -31,6 +31,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -30,6 +30,7 @@ RUN set -x \
 	&& makeOpts=' \
 		TARGET=linux2628 \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
 		USE_PCRE=1 PCREDIR= \
 		USE_ZLIB=1 \


### PR DESCRIPTION
Final release is planned for the end of the month: https://www.mail-archive.com/haproxy@formilux.org/msg33781.html

This pull request serves as a first smoke test, I don't expect any breakage, though.

---

I'd like to point out this paragraph from #79 as well:

> It should also be evaluated whether the haproxy:1 alias makes sense. The next version will be called 2.0 while not making any breaking changes to the best of my knowledge.

We should think about dropping `haproxy:1` and `haproxy:2` aliases and instead only provide `:latest` and the various “minor” versions. HAProxy 2.1 will remove some long-deprecated configuration options, though: https://www.mail-archive.com/haproxy@formilux.org/msg33580.html