### PR TITLE
Update generate-stackbrew-library.sh for 2.0

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,8 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[1.9]='1 latest'
+	[1.9]='1'
+	[2.0]='latest'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Forgot in #89. Why isn't this done by `update.sh` :unamused: :grinning: 