### PR TITLE
Switch to PCRE 2 and enable PCRE JIT

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x \
 		ca-certificates \
 		gcc \
 		libc6-dev \
-		libpcre3-dev \
+		libpcre2-dev \
 		libssl1.0-dev \
 		make \
 		wget \
@@ -30,7 +30,7 @@ RUN set -x \
 		TARGET=linux2628 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
-		pcre-dev \
+		pcre2-dev \
 		readline-dev \
 		tar \
 		zlib-dev \
@@ -31,7 +31,7 @@ RUN set -x \
 		TARGET=linux2628 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 		gcc \
 		libc6-dev \
 		liblua5.3-dev \
-		libpcre3-dev \
+		libpcre2-dev \
 		libssl1.0-dev \
 		make \
 		wget \
@@ -32,7 +32,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
-		pcre-dev \
+		pcre2-dev \
 		readline-dev \
 		tar \
 		zlib-dev \
@@ -33,7 +33,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \

--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 		gcc \
 		libc6-dev \
 		liblua5.3-dev \
-		libpcre3-dev \
+		libpcre2-dev \
 		libssl-dev \
 		make \
 		wget \
@@ -32,7 +32,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
-		pcre-dev \
+		pcre2-dev \
 		readline-dev \
 		tar \
 		zlib-dev \
@@ -33,7 +33,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 		gcc \
 		libc6-dev \
 		liblua5.3-dev \
-		libpcre3-dev \
+		libpcre2-dev \
 		libssl-dev \
 		make \
 		wget \
@@ -32,7 +32,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \

--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
-		pcre-dev \
+		pcre2-dev \
 		readline-dev \
 		tar \
 		zlib-dev \
@@ -33,7 +33,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 		gcc \
 		libc6-dev \
 		liblua5.3-dev \
-		libpcre3-dev \
+		libpcre2-dev \
 		libssl-dev \
 		make \
 		wget \
@@ -32,7 +32,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \

--- a/1.9/alpine/Dockerfile
+++ b/1.9/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
-		pcre-dev \
+		pcre2-dev \
 		readline-dev \
 		tar \
 		zlib-dev \
@@ -33,7 +33,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 		gcc \
 		libc6-dev \
 		liblua5.3-dev \
-		libpcre3-dev \
+		libpcre2-dev \
 		libssl-dev \
 		make \
 		wget \
@@ -32,7 +32,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \

--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
-		pcre-dev \
+		pcre2-dev \
 		readline-dev \
 		tar \
 		zlib-dev \
@@ -33,7 +33,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -17,7 +17,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
-		pcre-dev \
+		pcre2-dev \
 		readline-dev \
 		tar \
 		zlib-dev \
@@ -33,7 +33,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(getconf _NPROCESSORS_ONLN)" all $makeOpts \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -14,7 +14,7 @@ RUN set -x \
 		gcc \
 		libc6-dev \
 		liblua5.3-dev \
-		libpcre3-dev \
+		libpcre2-dev \
 		libssl-dev \
 		make \
 		wget \
@@ -32,7 +32,7 @@ RUN set -x \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_GETADDRINFO=1 \
 		USE_OPENSSL=1 \
-		USE_PCRE=1 PCREDIR= \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
 	' \
 	&& make -C /usr/src/haproxy -j "$(nproc)" all $makeOpts \


### PR DESCRIPTION
This is the last one for now, I promise!

------

The Debian package uses PCRE 2 by now and pcre.org says:

> There are two major versions of the PCRE library. The current version,
> PCRE2, first released in 2015, is now at version 10.33.
>
> The older, but still widely deployed PCRE library, originally released in
> 1997, is at version 8.43. Its API and feature set are stable—future
> releases will be for bugfixes only. Any new features will be added to
> PCRE2, and not to the PCRE 8.x series.

Note: libpcre3 in Debian is PCRE 1.