### PR TITLE
Add HAProxy 2.2-dev5 as 2.2-rc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: bash
 services: docker
 
 env:
+  - VERSION=2.2-rc VARIANT=
+  - VERSION=2.2-rc ARCH=i386
+  - VERSION=2.2-rc VARIANT=alpine
   - VERSION=2.1 VARIANT=
   - VERSION=2.1 ARCH=i386
   - VERSION=2.1 VARIANT=alpine

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -35,6 +35,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux2628 target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 		" \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -36,6 +36,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux2628 target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 		" \

--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -35,6 +35,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux2628 target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 		" \

--- a/1.9/alpine/Dockerfile
+++ b/1.9/alpine/Dockerfile
@@ -35,6 +35,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux2628 target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 		" \

--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -35,6 +35,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux-glibc target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 # see https://github.com/docker-library/haproxy/issues/94#issuecomment-505673353 for more details about prometheus support

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -35,6 +35,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux-glibc target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 # see https://github.com/docker-library/haproxy/issues/94#issuecomment-505673353 for more details about prometheus support

--- a/2.2-rc/Dockerfile
+++ b/2.2-rc/Dockerfile
@@ -1,0 +1,70 @@
+# vim:set ft=dockerfile:
+FROM debian:buster-slim
+
+ENV HAPROXY_VERSION 2.2-dev5
+ENV HAPROXY_URL https://www.haproxy.org/download/2.2/src/devel/haproxy-2.2-dev5.tar.gz
+ENV HAPROXY_SHA256 21ca1d2cfa56bc164ee9931300972c99e51b966408f05784eb16f581b6f62c7d
+
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& savedAptMark="$(apt-mark showmanual)" \
+	&& apt-get update && apt-get install -y --no-install-recommends \
+		ca-certificates \
+		gcc \
+		libc6-dev \
+		liblua5.3-dev \
+		libpcre2-dev \
+		libssl-dev \
+		make \
+		wget \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget -O haproxy.tar.gz "$HAPROXY_URL" \
+	&& echo "$HAPROXY_SHA256 *haproxy.tar.gz" | sha256sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux-glibc \
+		USE_GETADDRINFO=1 \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
+		USE_OPENSSL=1 \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
+		USE_ZLIB=1 \
+		\
+		EXTRA_OBJS=" \
+# see https://github.com/docker-library/haproxy/issues/94#issuecomment-505673353 for more details about prometheus support
+			contrib/prometheus-exporter/service-prometheus.o \
+		" \
+	' \
+	&& nproc="$(nproc)" \
+	&& eval "make -C /usr/src/haproxy -j '$nproc' all $makeOpts" \
+	&& eval "make -C /usr/src/haproxy install-bin $makeOpts" \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& apt-mark auto '.*' > /dev/null \
+	&& { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
+	&& find /usr/local -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| sort -u \
+		| xargs -r dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| xargs -r apt-mark manual \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+
+# https://www.haproxy.org/download/1.8/doc/management.txt
+# "4. Stopping and restarting HAProxy"
+# "when the SIGTERM signal is sent to the haproxy process, it immediately quits and all established connections are closed"
+# "graceful stop is triggered when the SIGUSR1 signal is sent to the haproxy process"
+STOPSIGNAL SIGUSR1
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.2-rc/alpine/Dockerfile
+++ b/2.2-rc/alpine/Dockerfile
@@ -35,6 +35,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux-glibc target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 # see https://github.com/docker-library/haproxy/issues/94#issuecomment-505673353 for more details about prometheus support

--- a/2.2-rc/alpine/Dockerfile
+++ b/2.2-rc/alpine/Dockerfile
@@ -1,0 +1,69 @@
+# vim:set ft=dockerfile:
+FROM alpine:3.11
+
+ENV HAPROXY_VERSION 2.2-dev5
+ENV HAPROXY_URL https://www.haproxy.org/download/2.2/src/devel/haproxy-2.2-dev5.tar.gz
+ENV HAPROXY_SHA256 21ca1d2cfa56bc164ee9931300972c99e51b966408f05784eb16f581b6f62c7d
+
+# see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
+RUN set -x \
+	\
+	&& apk add --no-cache --virtual .build-deps \
+		ca-certificates \
+		gcc \
+		libc-dev \
+		linux-headers \
+		lua5.3-dev \
+		make \
+		openssl \
+		openssl-dev \
+		pcre2-dev \
+		readline-dev \
+		tar \
+		zlib-dev \
+	\
+	&& wget -O haproxy.tar.gz "$HAPROXY_URL" \
+	&& echo "$HAPROXY_SHA256 *haproxy.tar.gz" | sha256sum -c \
+	&& mkdir -p /usr/src/haproxy \
+	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
+	&& rm haproxy.tar.gz \
+	\
+	&& makeOpts=' \
+		TARGET=linux-glibc \
+		USE_GETADDRINFO=1 \
+		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
+		USE_OPENSSL=1 \
+		USE_PCRE2=1 USE_PCRE2_JIT=1 \
+		USE_ZLIB=1 \
+		\
+		EXTRA_OBJS=" \
+# see https://github.com/docker-library/haproxy/issues/94#issuecomment-505673353 for more details about prometheus support
+			contrib/prometheus-exporter/service-prometheus.o \
+		" \
+	' \
+	&& nproc="$(getconf _NPROCESSORS_ONLN)" \
+	&& eval "make -C /usr/src/haproxy -j '$nproc' all $makeOpts" \
+	&& eval "make -C /usr/src/haproxy install-bin $makeOpts" \
+	\
+	&& mkdir -p /usr/local/etc/haproxy \
+	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors \
+	&& rm -rf /usr/src/haproxy \
+	\
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& apk add --no-network --virtual .haproxy-rundeps $runDeps \
+	&& apk del --no-network .build-deps
+
+# https://www.haproxy.org/download/1.8/doc/management.txt
+# "4. Stopping and restarting HAProxy"
+# "when the SIGTERM signal is sent to the haproxy process, it immediately quits and all established connections are closed"
+# "graceful stop is triggered when the SIGUSR1 signal is sent to the haproxy process"
+STOPSIGNAL SIGUSR1
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.2-rc/alpine/docker-entrypoint.sh
+++ b/2.2-rc/alpine/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	shift # "haproxy"
+	# if the user wants "haproxy", let's add a couple useful flags
+	#   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
+	#   -db -- disables background mode
+	set -- haproxy -W -db "$@"
+fi
+
+exec "$@"

--- a/2.2-rc/docker-entrypoint.sh
+++ b/2.2-rc/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- haproxy "$@"
+fi
+
+if [ "$1" = 'haproxy' ]; then
+	shift # "haproxy"
+	# if the user wants "haproxy", let's add a couple useful flags
+	#   -W  -- "master-worker mode" (similar to the old "haproxy-systemd-wrapper"; allows for reload via "SIGUSR2")
+	#   -db -- disables background mode
+	set -- haproxy -W -db "$@"
+fi
+
+exec "$@"

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -35,6 +35,8 @@ RUN set -x \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
+# USE_BACKTRACE is enabled by default on the linux-glibc target, but does not work with musl
+		USE_BACKTRACE= \
 		\
 		EXTRA_OBJS=" \
 # see https://github.com/docker-library/haproxy/issues/94#issuecomment-505673353 for more details about prometheus support


### PR DESCRIPTION
With 2.2-dev5 HAProxy 2.2 is nearing the end of the development cycle: https://www.mail-archive.com/haproxy@formilux.org/msg36774.html

It's a good opportunity to add prepare the Docker image. The Dockerfile is identical to the 2.1 one. 

There's one (or rather two) new Makefile option that might or might not the set: [`HLUA_PREPEND_PATH`](https://github.com/haproxy/haproxy/blob/3328f1859645ac97ce6725aa7311e6bf73aacf9c/Makefile#L87-L88) which adds a folder to the Lua search path similar to the new [`lua-prepend-path`](http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#3.1-lua-prepend-path) configuration option. I don't think it's super useful in the context of Docker, because it's a single purpose image and users can simply plug their scripts into the global Lua path, without polluting something else.