### PR TITLE
[CVE-2020-11100] Update to HAProxy 2.1.4, 2.0.14, 1.9.15, 1.8.25

### DIFF
--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM debian:buster-slim
 
-ENV HAPROXY_VERSION 1.8.24
-ENV HAPROXY_URL https://www.haproxy.org/download/1.8/src/haproxy-1.8.24.tar.gz
-ENV HAPROXY_SHA256 da4bc3db58105f2016a706b5c0242a6c870266c69581146ac7c363210604771a
+ENV HAPROXY_VERSION 1.8.25
+ENV HAPROXY_URL https://www.haproxy.org/download/1.8/src/haproxy-1.8.25.tar.gz
+ENV HAPROXY_SHA256 62c0b77de2275a54a443a869947ddcca2bad7bdc1cafd804732a0e0d59b1708b
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM alpine:3.11
 
-ENV HAPROXY_VERSION 1.8.24
-ENV HAPROXY_URL https://www.haproxy.org/download/1.8/src/haproxy-1.8.24.tar.gz
-ENV HAPROXY_SHA256 da4bc3db58105f2016a706b5c0242a6c870266c69581146ac7c363210604771a
+ENV HAPROXY_VERSION 1.8.25
+ENV HAPROXY_URL https://www.haproxy.org/download/1.8/src/haproxy-1.8.25.tar.gz
+ENV HAPROXY_SHA256 62c0b77de2275a54a443a869947ddcca2bad7bdc1cafd804732a0e0d59b1708b
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM debian:buster-slim
 
-ENV HAPROXY_VERSION 1.9.14
-ENV HAPROXY_URL https://www.haproxy.org/download/1.9/src/haproxy-1.9.14.tar.gz
-ENV HAPROXY_SHA256 d4bd6c58547cfd282feaef195d816b26145be19e494bf3486bb7187f7982296f
+ENV HAPROXY_VERSION 1.9.15
+ENV HAPROXY_URL https://www.haproxy.org/download/1.9/src/haproxy-1.9.15.tar.gz
+ENV HAPROXY_SHA256 291871c7f0145da14cc7222d2f68d3a0ec1c10734d91fd933226d3a103aebea5
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/1.9/alpine/Dockerfile
+++ b/1.9/alpine/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM alpine:3.11
 
-ENV HAPROXY_VERSION 1.9.14
-ENV HAPROXY_URL https://www.haproxy.org/download/1.9/src/haproxy-1.9.14.tar.gz
-ENV HAPROXY_SHA256 d4bd6c58547cfd282feaef195d816b26145be19e494bf3486bb7187f7982296f
+ENV HAPROXY_VERSION 1.9.15
+ENV HAPROXY_URL https://www.haproxy.org/download/1.9/src/haproxy-1.9.15.tar.gz
+ENV HAPROXY_SHA256 291871c7f0145da14cc7222d2f68d3a0ec1c10734d91fd933226d3a103aebea5
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM debian:buster-slim
 
-ENV HAPROXY_VERSION 2.0.13
-ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.13.tar.gz
-ENV HAPROXY_SHA256 21f932ae18131ad58cb2f9d7cf2338349b6ccf3f5c33382624bbf1d3760b9be1
+ENV HAPROXY_VERSION 2.0.14
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.14.tar.gz
+ENV HAPROXY_SHA256 552a708b8b6efd0f241f5d9fd7ad4168d37ce17cdb6dcb6239c2e519f0a63c75
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM alpine:3.11
 
-ENV HAPROXY_VERSION 2.0.13
-ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.13.tar.gz
-ENV HAPROXY_SHA256 21f932ae18131ad58cb2f9d7cf2338349b6ccf3f5c33382624bbf1d3760b9be1
+ENV HAPROXY_VERSION 2.0.14
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.14.tar.gz
+ENV HAPROXY_SHA256 552a708b8b6efd0f241f5d9fd7ad4168d37ce17cdb6dcb6239c2e519f0a63c75
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM debian:buster-slim
 
-ENV HAPROXY_VERSION 2.1.3
-ENV HAPROXY_URL https://www.haproxy.org/download/2.1/src/haproxy-2.1.3.tar.gz
-ENV HAPROXY_SHA256 bb678e550374d0d9d9312885fb9d270b501dae9e3b336f0a4379c667dae00b59
+ENV HAPROXY_VERSION 2.1.4
+ENV HAPROXY_URL https://www.haproxy.org/download/2.1/src/haproxy-2.1.4.tar.gz
+ENV HAPROXY_SHA256 51030ff696d7067162b4d24d354044293aecfbb36d7acc2f840c8d928bfe91cd
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM alpine:3.11
 
-ENV HAPROXY_VERSION 2.1.3
-ENV HAPROXY_URL https://www.haproxy.org/download/2.1/src/haproxy-2.1.3.tar.gz
-ENV HAPROXY_SHA256 bb678e550374d0d9d9312885fb9d270b501dae9e3b336f0a4379c667dae00b59
+ENV HAPROXY_VERSION 2.1.4
+ENV HAPROXY_URL https://www.haproxy.org/download/2.1/src/haproxy-2.1.4.tar.gz
+ENV HAPROXY_SHA256 51030ff696d7067162b4d24d354044293aecfbb36d7acc2f840c8d928bfe91cd
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \


### PR DESCRIPTION
see: https://www.mail-archive.com/haproxy@formilux.org/msg36876.html