### PR TITLE
Include iproute2

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -12,6 +12,7 @@ RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends \
 		ca-certificates \
 		gcc \
+		iproute2 \
 		libc6-dev \
 		liblua5.3-dev \
 		libpcre2-dev \


### PR DESCRIPTION
I'm running haproxy encapsulated in docker on some hosts, and there are processes (syslog, mostly) running on the host machine. The primary way I've seen to set this up, aside from really digging in to iptables, is to run something like
```sh
export HOST_IP=$(ip route show | awk '/default/ {print $3}')
```

This evaluates to something like
```
root@3386eb718c1f:/# ip route show | awk '/default/ {print $3}'
172.17.0.1
```

I made the change in one version to be explicit what I'm asking for, if y'all are good with it then I'm happy to update the others as well

I know I can get around this with my own docker image, but it'd be nice to have this baked in and I figure nothing lost by asking!