### PR TITLE
Remove "ca-certificates" package from Alpine build-deps

### DIFF
--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -9,7 +9,6 @@ ENV HAPROXY_SHA256 4118178b553a107b227f3f84774c7a50ae0b3ac2be39211c3db511ed4efe4
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \

--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -9,7 +9,6 @@ ENV HAPROXY_SHA256 62c0b77de2275a54a443a869947ddcca2bad7bdc1cafd804732a0e0d59b17
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \

--- a/1.9/alpine/Dockerfile
+++ b/1.9/alpine/Dockerfile
@@ -9,7 +9,6 @@ ENV HAPROXY_SHA256 291871c7f0145da14cc7222d2f68d3a0ec1c10734d91fd933226d3a103aeb
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \

--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -9,7 +9,6 @@ ENV HAPROXY_SHA256 6e21c6b92d4035ee006ef18e25f396d7e71552a6d3a1e075fa9fe59d89eaa
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -9,7 +9,6 @@ ENV HAPROXY_SHA256 392e6cf18e75fe7e166102e8c4512942890a0b5ae738f6064faab4687f60a
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \

--- a/2.2-rc/alpine/Dockerfile
+++ b/2.2-rc/alpine/Dockerfile
@@ -9,7 +9,6 @@ ENV HAPROXY_SHA256 55cf096f2e34ff70085c9bc4606d3e72d1c6ae23a9c9386f8b19b4f09bb84
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -9,7 +9,6 @@ ENV HAPROXY_SHA256 %%HAPROXY_SHA256%%
 RUN set -x \
 	\
 	&& apk add --no-cache --virtual .build-deps \
-		ca-certificates \
 		gcc \
 		libc-dev \
 		linux-headers \


### PR DESCRIPTION
The CA bundle necessary for downloading from "https://www.haproxy.org" is already included in the base, and there's a fun bug where installing and then uninstalling the `ca-certificates` package removes what we need (see https://github.com/docker-library/haproxy/issues/117#issuecomment-645615214).

Closes #117