### PR TITLE
Update to 2.0.16

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM debian:buster-slim
 
-ENV HAPROXY_VERSION 2.0.15
-ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.15.tar.gz
-ENV HAPROXY_SHA256 6e21c6b92d4035ee006ef18e25f396d7e71552a6d3a1e075fa9fe59d89eaaeee
+ENV HAPROXY_VERSION 2.0.16
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.16.tar.gz
+ENV HAPROXY_SHA256 8eda217f3bf82f7ad6353bfd0c2005c4ac2da6cdca0398cf98de0016cdb97385
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \

--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -1,9 +1,9 @@
 # vim:set ft=dockerfile:
 FROM alpine:3.12
 
-ENV HAPROXY_VERSION 2.0.15
-ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.15.tar.gz
-ENV HAPROXY_SHA256 6e21c6b92d4035ee006ef18e25f396d7e71552a6d3a1e075fa9fe59d89eaaeee
+ENV HAPROXY_VERSION 2.0.16
+ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.16.tar.gz
+ENV HAPROXY_SHA256 8eda217f3bf82f7ad6353bfd0c2005c4ac2da6cdca0398cf98de0016cdb97385
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -x \
@@ -26,6 +26,10 @@ RUN set -x \
 	&& mkdir -p /usr/src/haproxy \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
+# https://github.com/haproxy/haproxy/issues/760 ("ebtree/ebtree.c:43:2: error: unknown type name 'ssize_t'; did you mean 'size_t'?")
+	&& ! grep -qF 'unistd.h' /usr/src/haproxy/ebtree/ebtree.c \
+	&& awk '$1 == "#include" && !inc { print "#include <unistd.h>"; inc = 1 } { print }' /usr/src/haproxy/ebtree/ebtree.c > ebtree.c \
+	&& mv ebtree.c /usr/src/haproxy/ebtree/ebtree.c \
 	\
 	&& makeOpts=' \
 		TARGET=linux-glibc \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -26,6 +26,10 @@ RUN set -x \
 	&& mkdir -p /usr/src/haproxy \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
+# https://github.com/haproxy/haproxy/issues/760 ("ebtree/ebtree.c:43:2: error: unknown type name 'ssize_t'; did you mean 'size_t'?")
+	&& ! grep -qF 'unistd.h' /usr/src/haproxy/ebtree/ebtree.c \
+	&& awk '$1 == "#include" && !inc { print "#include <unistd.h>"; inc = 1 } { print }' /usr/src/haproxy/ebtree/ebtree.c > ebtree.c \
+	&& mv ebtree.c /usr/src/haproxy/ebtree/ebtree.c \
 	\
 	&& makeOpts=' \
 		TARGET=linux-musl \

--- a/update.sh
+++ b/update.sh
@@ -68,6 +68,10 @@ for version in "${versions[@]}"; do
 		sedExpr+='
 			s/linux-musl/linux-glibc/;
 		'
+	else
+		sedExpr+='
+			/ebtree/d
+		'
 	fi
 	sed -r "$sedExpr" 'Dockerfile-debian.template' > "$version/Dockerfile"
 


### PR DESCRIPTION
(CI is going to fail to build `haproxy:2.0-alpine` in the same way it's failing at https://doi-janky.infosiftr.net/job/update.sh/job/haproxy/, but I want to get it open to have a better place to link back to in an issue at https://github.com/haproxy/haproxy/issues)

```console
...
Step 5/9 : RUN set -x 		&& apk add --no-cache --virtual .build-deps 		gcc 		libc-dev 		linux-headers 		lua5.3-dev 		make 		openssl 		openssl-dev 		pcre2-dev 		readline-dev 		tar 		zlib-dev 		&& wget -O haproxy.tar.gz "$HAPROXY_URL" 	&& echo "$HAPROXY_SHA256 *haproxy.tar.gz" | sha256sum -c 	&& mkdir -p /usr/src/haproxy 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 	&& rm haproxy.tar.gz 		&& makeOpts=' 		TARGET=linux-glibc 		USE_GETADDRINFO=1 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 		USE_OPENSSL=1 		USE_PCRE2=1 USE_PCRE2_JIT=1 		USE_ZLIB=1 				EXTRA_OBJS=" 			contrib/prometheus-exporter/service-prometheus.o 		" 	' 	&& nproc="$(getconf _NPROCESSORS_ONLN)" 	&& eval "make -C /usr/src/haproxy -j '$nproc' all $makeOpts" 	&& eval "make -C /usr/src/haproxy install-bin $makeOpts" 		&& mkdir -p /usr/local/etc/haproxy 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors 	&& rm -rf /usr/src/haproxy 		&& runDeps="$( 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local 			| tr ',' '\n' 			| sort -u 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' 	)" 	&& apk add --no-network --virtual .haproxy-rundeps $runDeps 	&& apk del --no-network .build-deps
 ---> Running in b29cb86d2e4c
+ apk add --no-cache --virtual .build-deps gcc libc-dev linux-headers lua5.3-dev make openssl openssl-dev pcre2-dev readline-dev tar zlib-dev
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/39) Upgrading musl (1.1.24-r8 -> 1.1.24-r9)
(2/39) Installing libgcc (9.3.0-r2)
(3/39) Installing libstdc++ (9.3.0-r2)
(4/39) Installing binutils (2.34-r1)
(5/39) Installing gmp (6.2.0-r0)
(6/39) Installing isl (0.18-r0)
(7/39) Installing libgomp (9.3.0-r2)
(8/39) Installing libatomic (9.3.0-r2)
(9/39) Installing libgphobos (9.3.0-r2)
(10/39) Installing mpfr4 (4.0.2-r4)
(11/39) Installing mpc1 (1.1.0-r1)
(12/39) Installing gcc (9.3.0-r2)
(13/39) Installing musl-dev (1.1.24-r9)
(14/39) Installing libc-dev (0.7.2-r3)
(15/39) Installing linux-headers (5.4.5-r1)
(16/39) Installing linenoise (1.0-r1)
(17/39) Installing lua5.3-libs (5.3.5-r6)
(18/39) Installing lua5.3 (5.3.5-r6)
(19/39) Installing pkgconf (1.7.2-r0)
(20/39) Installing lua5.3-dev (5.3.5-r6)
(21/39) Installing make (4.3-r0)
(22/39) Installing openssl (1.1.1g-r0)
(23/39) Installing openssl-dev (1.1.1g-r0)
(24/39) Installing ncurses-terminfo-base (6.2_p20200523-r0)
(25/39) Installing ncurses-libs (6.2_p20200523-r0)
(26/39) Installing ncurses-dev (6.2_p20200523-r0)
(27/39) Installing libedit (20191231.3.1-r0)
(28/39) Installing libedit-dev (20191231.3.1-r0)
(29/39) Installing zlib-dev (1.2.11-r3)
(30/39) Installing libpcre2-16 (10.35-r0)
(31/39) Installing libpcre2-32 (10.35-r0)
(32/39) Installing pcre2 (10.35-r0)
(33/39) Installing pcre2-dev (10.35-r0)
(34/39) Installing libhistory (8.0.4-r0)
(35/39) Installing readline (8.0.4-r0)
(36/39) Installing readline-dev (8.0.4-r0)
(37/39) Installing libacl (2.2.53-r0)
(38/39) Installing tar (1.32-r1)
(39/39) Installing .build-deps (20200717.160049)
Executing busybox-1.31.1-r16.trigger
OK: 157 MiB in 52 packages
+ wget -O haproxy.tar.gz https://www.haproxy.org/download/2.0/src/haproxy-2.0.16.tar.gz
Connecting to www.haproxy.org (51.15.8.218:443)
saving to 'haproxy.tar.gz'
haproxy.tar.gz        30% |*********                       |  797k  0:00:02 ETA
haproxy.tar.gz       100% |********************************| 2612k  0:00:00 ETA
'haproxy.tar.gz' saved
+ echo '8eda217f3bf82f7ad6353bfd0c2005c4ac2da6cdca0398cf98de0016cdb97385 *haproxy.tar.gz'
+ sha256sum -c
haproxy.tar.gz: OK
+ mkdir -p /usr/src/haproxy
+ tar -xzf haproxy.tar.gz -C /usr/src/haproxy '--strip-components=1'
+ rm haproxy.tar.gz
+ makeOpts=' 		TARGET=linux-glibc 		USE_GETADDRINFO=1 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 		USE_OPENSSL=1 		USE_PCRE2=1 USE_PCRE2_JIT=1 		USE_ZLIB=1 				EXTRA_OBJS=" 			contrib/prometheus-exporter/service-prometheus.o 		" 	'
+ getconf _NPROCESSORS_ONLN
+ nproc=4
+ eval 'make -C /usr/src/haproxy -j '"'"'4'"'"' all  		TARGET=linux-glibc 		USE_GETADDRINFO=1 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 		USE_OPENSSL=1 		USE_PCRE2=1 USE_PCRE2_JIT=1 		USE_ZLIB=1 				EXTRA_OBJS=" 			contrib/prometheus-exporter/service-prometheus.o 		" 	'
+ make -C /usr/src/haproxy -j 4 all 'TARGET=linux-glibc' 'USE_GETADDRINFO=1' 'USE_LUA=1' 'LUA_INC=/usr/include/lua5.3' 'LUA_LIB=/usr/lib/lua5.3' 'USE_OPENSSL=1' 'USE_PCRE2=1' 'USE_PCRE2_JIT=1' 'USE_ZLIB=1' 'EXTRA_OBJS= 			contrib/prometheus-exporter/service-prometheus.o 		'
make: Entering directory '/usr/src/haproxy'
  CC      src/ev_poll.o
  CC      src/ev_epoll.o
  CC      src/ssl_sock.o
  CC      src/hlua.o
  CC      src/hlua_fcn.o
  CC      src/namespace.o
  CC      src/proto_http.o
  CC      src/cfgparse-listen.o
  CC      src/proto_htx.o
  CC      src/stream.o
  CC      src/mux_h2.o
  CC      src/stats.o
  CC      src/flt_spoe.o
  CC      src/server.o
  CC      src/checks.o
  CC      src/haproxy.o
  CC      src/cfgparse.o
  CC      src/flt_http_comp.o
  CC      src/http_fetch.o
  CC      src/dns.o
  CC      src/stick_table.o
  CC      src/mux_h1.o
  CC      src/peers.o
  CC      src/standard.o
  CC      src/proxy.o
  CC      src/cli.o
  CC      src/log.o
  CC      src/backend.o
  CC      src/pattern.o
  CC      src/sample.o
  CC      src/stream_interface.o
  CC      src/proto_tcp.o
  CC      src/listener.o
  CC      src/h1.o
  CC      src/cfgparse-global.o
  CC      src/cache.o
  CC      src/http_rules.o
  CC      src/http_act.o
  CC      src/tcp_rules.o
  CC      src/filters.o
  CC      src/connection.o
  CC      src/session.o
  CC      src/acl.o
  CC      src/vars.o
  CC      src/raw_sock.o
  CC      src/map.o
  CC      src/proto_uxst.o
  CC      src/payload.o
  CC      src/fd.o
  CC      src/queue.o
  CC      src/flt_trace.o
  CC      src/task.o
  CC      src/lb_chash.o
  CC      src/frontend.o
  CC      src/applet.o
  CC      src/mux_pt.o
  CC      src/signal.o
  CC      src/ev_select.o
  CC      src/proto_sockpair.o
  CC      src/compression.o
  CC      src/http_conv.o
  CC      src/memory.o
  CC      src/lb_fwrr.o
  CC      src/channel.o
  CC      src/htx.o
  CC      src/uri_auth.o
  CC      src/regex.o
  CC      src/chunk.o
  CC      src/pipe.o
  CC      src/lb_fas.o
  CC      src/lb_map.o
  CC      src/lb_fwlc.o
  CC      src/auth.o
  CC      src/time.o
  CC      src/hathreads.o
  CC      src/http_htx.o
  CC      src/buffer.o
  CC      src/hpack-tbl.o
  CC      src/shctx.o
  CC      src/sha1.o
  CC      src/http.o
  CC      src/hpack-dec.o
  CC      src/action.o
  CC      src/proto_udp.o
  CC      src/http_acl.o
  CC      src/xxhash.o
  CC      src/hpack-enc.o
  CC      src/h2.o
  CC      src/freq_ctr.o
  CC      src/lru.o
  CC      src/protocol.o
  CC      src/arg.o
  CC      src/hpack-huff.o
  CC      src/hdr_idx.o
  CC      src/base64.o
  CC      src/hash.o
  CC      src/mailers.o
  CC      src/activity.o
  CC      src/http_msg.o
  CC      src/version.o
  CC      src/mworker.o
  CC      src/mworker-prog.o
  CC      src/debug.o
  CC      src/wdt.o
  CC      src/dict.o
  CC      src/xprt_handshake.o
  CC      contrib/prometheus-exporter/service-prometheus.o
  CC      ebtree/ebtree.o
ebtree/ebtree.c: In function 'eb_memcmp':
ebtree/ebtree.c:43:2: error: unknown type name 'ssize_t'; did you mean 'size_t'?
   43 |  ssize_t ofs = -len;
      |  ^~~~~~~
      |  size_t
make: *** [Makefile:845: ebtree/ebtree.o] Error 1
make: *** Waiting for unfinished jobs....
make: Leaving directory '/usr/src/haproxy'
Removing intermediate container b29cb86d2e4c
The command '/bin/sh -c set -x 		&& apk add --no-cache --virtual .build-deps 		gcc 		libc-dev 		linux-headers 		lua5.3-dev 		make 		openssl 		openssl-dev 		pcre2-dev 		readline-dev 		tar 		zlib-dev 		&& wget -O haproxy.tar.gz "$HAPROXY_URL" 	&& echo "$HAPROXY_SHA256 *haproxy.tar.gz" | sha256sum -c 	&& mkdir -p /usr/src/haproxy 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 	&& rm haproxy.tar.gz 		&& makeOpts=' 		TARGET=linux-glibc 		USE_GETADDRINFO=1 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 		USE_OPENSSL=1 		USE_PCRE2=1 USE_PCRE2_JIT=1 		USE_ZLIB=1 				EXTRA_OBJS=" 			contrib/prometheus-exporter/service-prometheus.o 		" 	' 	&& nproc="$(getconf _NPROCESSORS_ONLN)" 	&& eval "make -C /usr/src/haproxy -j '$nproc' all $makeOpts" 	&& eval "make -C /usr/src/haproxy install-bin $makeOpts" 		&& mkdir -p /usr/local/etc/haproxy 	&& cp -R /usr/src/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors 	&& rm -rf /usr/src/haproxy 		&& runDeps="$( 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local 			| tr ',' '\n' 			| sort -u 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' 	)" 	&& apk add --no-network --virtual .haproxy-rundeps $runDeps 	&& apk del --no-network .build-deps' returned a non-zero code: 2
```

**Edit:** upstream bug filed at https://github.com/haproxy/haproxy/issues/760