### PR TITLE
Apply the canonical backported ebtree patch from upstream

### DIFF
--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -16,6 +16,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
+		patch \
 		pcre2-dev \
 		readline-dev \
 		tar \
@@ -27,9 +28,10 @@ RUN set -x \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
 # https://github.com/haproxy/haproxy/issues/760 ("ebtree/ebtree.c:43:2: error: unknown type name 'ssize_t'; did you mean 'size_t'?")
-	&& ! grep -qF 'unistd.h' /usr/src/haproxy/ebtree/ebtree.c \
-	&& awk '$1 == "#include" && !inc { print "#include <unistd.h>"; inc = 1 } { print }' /usr/src/haproxy/ebtree/ebtree.c > ebtree.c \
-	&& mv ebtree.c /usr/src/haproxy/ebtree/ebtree.c \
+#   ebtree patch/fix: https://git.haproxy.org/?p=haproxy-2.0.git;a=commit;h=5df32b51bb0c3c89b503d04cd7d31bdd77932370
+	&& wget -O ebtree.patch 'https://git.haproxy.org/?p=haproxy-2.0.git;a=patch;h=5df32b51bb0c3c89b503d04cd7d31bdd77932370' \
+	&& patch -p1 --input="$PWD/ebtree.patch" --directory=/usr/src/haproxy \
+	&& rm ebtree.patch \
 	\
 	&& makeOpts=' \
 		TARGET=linux-glibc \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -16,6 +16,7 @@ RUN set -x \
 		make \
 		openssl \
 		openssl-dev \
+		patch \
 		pcre2-dev \
 		readline-dev \
 		tar \
@@ -27,9 +28,10 @@ RUN set -x \
 	&& tar -xzf haproxy.tar.gz -C /usr/src/haproxy --strip-components=1 \
 	&& rm haproxy.tar.gz \
 # https://github.com/haproxy/haproxy/issues/760 ("ebtree/ebtree.c:43:2: error: unknown type name 'ssize_t'; did you mean 'size_t'?")
-	&& ! grep -qF 'unistd.h' /usr/src/haproxy/ebtree/ebtree.c \
-	&& awk '$1 == "#include" && !inc { print "#include <unistd.h>"; inc = 1 } { print }' /usr/src/haproxy/ebtree/ebtree.c > ebtree.c \
-	&& mv ebtree.c /usr/src/haproxy/ebtree/ebtree.c \
+#   ebtree patch/fix: https://git.haproxy.org/?p=haproxy-2.0.git;a=commit;h=5df32b51bb0c3c89b503d04cd7d31bdd77932370
+	&& wget -O ebtree.patch 'https://git.haproxy.org/?p=haproxy-2.0.git;a=patch;h=5df32b51bb0c3c89b503d04cd7d31bdd77932370' \
+	&& patch -p1 --input="$PWD/ebtree.patch" --directory=/usr/src/haproxy \
+	&& rm ebtree.patch \
 	\
 	&& makeOpts=' \
 		TARGET=linux-musl \

--- a/update.sh
+++ b/update.sh
@@ -71,6 +71,7 @@ for version in "${versions[@]}"; do
 	else
 		sedExpr+='
 			/ebtree/d
+			/patch/d
 		'
 	fi
 	sed -r "$sedExpr" 'Dockerfile-debian.template' > "$version/Dockerfile"


### PR DESCRIPTION
This switches us from my hanky `awk` one-liner to the actual backported patch from https://git.haproxy.org/?p=haproxy-2.0.git;a=commit;h=5df32b51bb0c3c89b503d04cd7d31bdd77932370.

Refs https://github.com/docker-library/haproxy/pull/126, https://github.com/haproxy/haproxy/issues/760