### PR TITLE
dockerfile: add better support for arm

### DIFF
--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -56,6 +56,7 @@ RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		armel) makeOpts="$makeOpts ADDLIB=-latomic" ;; \
+		arm64) makeOpts="$makeOpts CPU=native" ;; \
 	esac; \
 	\
 	nproc="$(nproc)"; \

--- a/2.4-rc/Dockerfile
+++ b/2.4-rc/Dockerfile
@@ -56,6 +56,7 @@ RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		armel) makeOpts="$makeOpts ADDLIB=-latomic" ;; \
+		arm64) makeOpts="$makeOpts CPU=native" ;; \
 	esac; \
 	\
 	nproc="$(nproc)"; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -56,6 +56,7 @@ RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 		armel) makeOpts="$makeOpts ADDLIB=-latomic" ;; \
+		arm64) makeOpts="$makeOpts CPU=native" ;; \
 	esac; \
 	\
 	nproc="$(nproc)"; \


### PR DESCRIPTION
As suggested by
https://www.mail-archive.com/haproxy@formilux.org/msg39085.html this
option will imrpove performances:
"A side note for those running haproxy on AWS's new ARM machines (t4g, m6g,
c6g, r6g): I could test the impact of the new ARMv8.1 atomic instructions
supported by these CPUs, and the gains in scalability are tremendous, with
16 cores I could observe a jump from 101k to 420k req/s. Said differently,
the older ones bring a huge overhead. If you're using haproxy there, do
not forget to add "CPU=native" to your build line to benefit from this,
and you'll probably need a much smaller machine for the same workload."