### PR TITLE
Disable ZLIB starting with HAProxy 2.4

### DIFF
--- a/2.4-rc/Dockerfile
+++ b/2.4-rc/Dockerfile
@@ -17,9 +17,9 @@ RUN set -eux; \
 		--uid 99 \
 		haproxy
 
-ENV HAPROXY_VERSION 2.4-dev16
-ENV HAPROXY_URL https://www.haproxy.org/download/2.4/src/devel/haproxy-2.4-dev16.tar.gz
-ENV HAPROXY_SHA256 7ba831c977ce80e26ed3ae6ecbc54c1ff3e8a313118b47b9d877ef44ad17cdf0
+ENV HAPROXY_VERSION 2.4-dev18
+ENV HAPROXY_URL https://www.haproxy.org/download/2.4/src/devel/haproxy-2.4-dev18.tar.gz
+ENV HAPROXY_SHA256 fab8b85664afc74c481c91a8f104b6bf87b265f9b5f03054dc926364e9801e74
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -eux; \
@@ -34,7 +34,6 @@ RUN set -eux; \
 		libssl-dev \
 		make \
 		wget \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
@@ -50,7 +49,6 @@ RUN set -eux; \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
-		USE_ZLIB=1 \
 		USE_PROMEX=1 \
 		\
 		EXTRA_OBJS=" \

--- a/2.4-rc/alpine/Dockerfile
+++ b/2.4-rc/alpine/Dockerfile
@@ -18,9 +18,9 @@ RUN set -eux; \
 		--uid 99 \
 		haproxy
 
-ENV HAPROXY_VERSION 2.4-dev16
-ENV HAPROXY_URL https://www.haproxy.org/download/2.4/src/devel/haproxy-2.4-dev16.tar.gz
-ENV HAPROXY_SHA256 7ba831c977ce80e26ed3ae6ecbc54c1ff3e8a313118b47b9d877ef44ad17cdf0
+ENV HAPROXY_VERSION 2.4-dev18
+ENV HAPROXY_URL https://www.haproxy.org/download/2.4/src/devel/haproxy-2.4-dev18.tar.gz
+ENV HAPROXY_SHA256 fab8b85664afc74c481c91a8f104b6bf87b265f9b5f03054dc926364e9801e74
 
 # see https://sources.debian.net/src/haproxy/jessie/debian/rules/ for some helpful navigation of the possible "make" arguments
 RUN set -eux; \
@@ -36,7 +36,6 @@ RUN set -eux; \
 		pcre2-dev \
 		readline-dev \
 		tar \
-		zlib-dev \
 	; \
 	\
 	wget -O haproxy.tar.gz "$HAPROXY_URL"; \
@@ -51,7 +50,6 @@ RUN set -eux; \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 LUA_LIB=/usr/lib/lua5.3 \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
-		USE_ZLIB=1 \
 		USE_PROMEX=1 \
 		\
 		EXTRA_OBJS=" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -90,7 +90,7 @@ RUN set -eux; \
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
 		USE_ZLIB=1 \
-{{ if env.version | startswith("2.") and ([ "2.0", "2.2", "2.3" ] | index(env.version) | not) then ( -}}
+{{ if ([ "1.7", "1.8", "2.0", "2.2", "2.3" ] | index(env.version) | not) then ( -}}
 		USE_PROMEX=1 \
 {{ ) else "" end -}}
 		\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -46,7 +46,9 @@ RUN set -eux; \
 		pcre2-dev \
 		readline-dev \
 		tar \
+{{ if ([ "1.7", "1.8", "2.0", "2.2", "2.3" ] | index(env.version)) then ( -}}
 		zlib-dev \
+{{ ) else "" end -}}
 	; \
 {{ ) else ( -}}
 	savedAptMark="$(apt-mark showmanual)"; \
@@ -59,7 +61,9 @@ RUN set -eux; \
 		libssl-dev \
 		make \
 		wget \
+{{ if ([ "1.7", "1.8", "2.0", "2.2", "2.3" ] | index(env.version)) then ( -}}
 		zlib1g-dev \
+{{ ) else "" end -}}
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
@@ -89,7 +93,9 @@ RUN set -eux; \
 		USE_LUA=1 LUA_INC=/usr/include/lua5.3 {{ if env.variant == "alpine" then "LUA_LIB=/usr/lib/lua5.3 " else "" end }}\
 		USE_OPENSSL=1 \
 		USE_PCRE2=1 USE_PCRE2_JIT=1 \
+{{ if ([ "1.7", "1.8", "2.0", "2.2", "2.3" ] | index(env.version)) then ( -}}
 		USE_ZLIB=1 \
+{{ ) else "" end -}}
 {{ if ([ "1.7", "1.8", "2.0", "2.2", "2.3" ] | index(env.version) | not) then ( -}}
 		USE_PROMEX=1 \
 {{ ) else "" end -}}

--- a/versions.json
+++ b/versions.json
@@ -37,8 +37,8 @@
   "2.4-rc": {
     "alpine": "3.13",
     "debian": "buster-slim",
-    "sha256": "7ba831c977ce80e26ed3ae6ecbc54c1ff3e8a313118b47b9d877ef44ad17cdf0",
-    "url": "https://www.haproxy.org/download/2.4/src/devel/haproxy-2.4-dev16.tar.gz",
-    "version": "2.4-dev16"
+    "sha256": "fab8b85664afc74c481c91a8f104b6bf87b265f9b5f03054dc926364e9801e74",
+    "url": "https://www.haproxy.org/download/2.4/src/devel/haproxy-2.4-dev18.tar.gz",
+    "version": "2.4-dev18"
   }
 }


### PR DESCRIPTION
SLZ is included by default and the recommended library:

haproxy/haproxy@12840be