### PR TITLE
Update to debian:bullseye-slim for 2.2+

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \

--- a/2.5-rc/Dockerfile
+++ b/2.5-rc/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \

--- a/versions.json
+++ b/versions.json
@@ -22,28 +22,28 @@
   },
   "2.2": {
     "alpine": "3.14",
-    "debian": "buster-slim",
+    "debian": "bullseye-slim",
     "sha256": "b81e03a181070d1f7bcdaeec9f09af701fb1ab015c3c9c997a881f4773e29375",
     "url": "https://www.haproxy.org/download/2.2/src/haproxy-2.2.16.tar.gz",
     "version": "2.2.16"
   },
   "2.3": {
     "alpine": "3.14",
-    "debian": "buster-slim",
+    "debian": "bullseye-slim",
     "sha256": "c651a44f1a1158085962ea64852ab163e0d21c5ef0ea4b2c5218728ed4dbe257",
     "url": "https://www.haproxy.org/download/2.3/src/haproxy-2.3.13.tar.gz",
     "version": "2.3.13"
   },
   "2.4": {
     "alpine": "3.14",
-    "debian": "buster-slim",
+    "debian": "bullseye-slim",
     "sha256": "ce479380be5464faa881dcd829618931b60130ffeb01c88bc2bf95e230046405",
     "url": "https://www.haproxy.org/download/2.4/src/haproxy-2.4.3.tar.gz",
     "version": "2.4.3"
   },
   "2.5-rc": {
     "alpine": "3.14",
-    "debian": "buster-slim",
+    "debian": "bullseye-slim",
     "sha256": "d0b3cffbf75a2ef3848624d9a6a26033d8a84e362e134830c5e5e2f935eeaadb",
     "url": "https://www.haproxy.org/download/2.5/src/devel/haproxy-2.5-dev5.tar.gz",
     "version": "2.5-dev5"

--- a/versions.sh
+++ b/versions.sh
@@ -12,9 +12,11 @@ else
 fi
 versions=( "${versions[@]%/}" )
 
-defaultDebianSuite='buster-slim'
+defaultDebianSuite='bullseye-slim'
 declare -A debianSuite=(
-	#[1.6]='stretch-slim'
+	[1.7]='buster-slim'
+	[1.8]='buster-slim'
+	[2.0]='buster-slim'
 )
 defaultAlpineVersion='3.14'
 declare -A alpineVersion=(


### PR DESCRIPTION
Older versions have not been adjusted to prefer stability. The EOL of HAProxy
2.0 nicely matches up the EOL of Debian Buster LTS and thus was choosen as the
cut-off point.