### PR TITLE
Add suite aliases ("alpine3.14", etc)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -103,6 +103,17 @@ for version; do
 		parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$dir/Dockerfile")"
 		arches="${parentRepoToArches[$parent]}"
 
+		suite="${parent#*:}" # "buster-slim", "buster"
+		suite="${suite%-slim}" # "buster"
+		if [ "$variant" = 'alpine' ]; then
+			suite="alpine$suite" # "alpine3.8"
+			suiteAliases=( "${versionAliases[@]/%/-$suite}" )
+		else
+			suiteAliases=( "${variantAliases[@]/%/-$suite}" )
+		fi
+		suiteAliases=( "${suiteAliases[@]//latest-/}" )
+		variantAliases+=( "${suiteAliases[@]}" )
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
This is a prerequisite of something like https://github.com/docker-library/haproxy/pull/167 to ensure users who can't update Docker for one reason or another have an escape hatch (which also means they won't update HAproxy either, but they can't have everything). :sweat_smile:

```diff
$ diff -u <(bashbrew cat haproxy) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2021-08-20 16:03:13.543529675 -0700
+++ /dev/fd/62	2021-08-20 16:03:13.543529675 -0700
@@ -1,72 +1,72 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev4, 2.5-dev
+Tags: 2.5-dev4, 2.5-dev, 2.5-dev4-buster, 2.5-dev-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.5-rc
 
-Tags: 2.5-dev4-alpine, 2.5-dev-alpine
+Tags: 2.5-dev4-alpine, 2.5-dev-alpine, 2.5-dev4-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.3, 2.4, lts, latest
+Tags: 2.4.3, 2.4, lts, latest, 2.4.3-buster, 2.4-buster, lts-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.4
 
-Tags: 2.4.3-alpine, 2.4-alpine, lts-alpine, alpine
+Tags: 2.4.3-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.3-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.4/alpine
 
-Tags: 2.3.13, 2.3
+Tags: 2.3.13, 2.3, 2.3.13-buster, 2.3-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.3
 
-Tags: 2.3.13-alpine, 2.3-alpine
+Tags: 2.3.13-alpine, 2.3-alpine, 2.3.13-alpine3.14, 2.3-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.3/alpine
 
-Tags: 2.2.16, 2.2
+Tags: 2.2.16, 2.2, 2.2.16-buster, 2.2-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.2
 
-Tags: 2.2.16-alpine, 2.2-alpine
+Tags: 2.2.16-alpine, 2.2-alpine, 2.2.16-alpine3.14, 2.2-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.2/alpine
 
-Tags: 2.0.24, 2.0
+Tags: 2.0.24, 2.0, 2.0.24-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.0
 
-Tags: 2.0.24-alpine, 2.0-alpine
+Tags: 2.0.24-alpine, 2.0-alpine, 2.0.24-alpine3.14, 2.0-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.0/alpine
 
-Tags: 1.8.30, 1.8
+Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 0e7b078d5ff2ed9f29e4223a5d3d38d191818505
 Directory: 1.8
 
-Tags: 1.8.30-alpine, 1.8-alpine
+Tags: 1.8.30-alpine, 1.8-alpine, 1.8.30-alpine3.14, 1.8-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
 Directory: 1.8/alpine
 
-Tags: 1.7.14, 1.7
+Tags: 1.7.14, 1.7, 1.7.14-buster, 1.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
 Directory: 1.7
 
-Tags: 1.7.14-alpine, 1.7-alpine
+Tags: 1.7.14-alpine, 1.7-alpine, 1.7.14-alpine3.12, 1.7-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
 Directory: 1.7/alpine
```