### PR TITLE
Create $HOME directory for haproxy user

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -15,7 +15,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 1.7.14
 ENV HAPROXY_URL https://www.haproxy.org/download/1.7/src/haproxy-1.7.14.tar.gz

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 1.7.14
 ENV HAPROXY_URL https://www.haproxy.org/download/1.7/src/haproxy-1.7.14.tar.gz

--- a/1.8/Dockerfile
+++ b/1.8/Dockerfile
@@ -15,7 +15,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 1.8.30
 ENV HAPROXY_URL https://www.haproxy.org/download/1.8/src/haproxy-1.8.30.tar.gz

--- a/1.8/alpine/Dockerfile
+++ b/1.8/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 1.8.30
 ENV HAPROXY_URL https://www.haproxy.org/download/1.8/src/haproxy-1.8.30.tar.gz

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -15,7 +15,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.0.25
 ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.25.tar.gz

--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.0.25
 ENV HAPROXY_URL https://www.haproxy.org/download/2.0/src/haproxy-2.0.25.tar.gz

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -15,7 +15,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.2.17
 ENV HAPROXY_URL https://www.haproxy.org/download/2.2/src/haproxy-2.2.17.tar.gz

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.2.17
 ENV HAPROXY_URL https://www.haproxy.org/download/2.2/src/haproxy-2.2.17.tar.gz

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -15,7 +15,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.3.14
 ENV HAPROXY_URL https://www.haproxy.org/download/2.3/src/haproxy-2.3.14.tar.gz

--- a/2.3/alpine/Dockerfile
+++ b/2.3/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.3.14
 ENV HAPROXY_URL https://www.haproxy.org/download/2.3/src/haproxy-2.3.14.tar.gz

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -15,7 +15,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.4.7
 ENV HAPROXY_URL https://www.haproxy.org/download/2.4/src/haproxy-2.4.7.tar.gz

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.4.7
 ENV HAPROXY_URL https://www.haproxy.org/download/2.4/src/haproxy-2.4.7.tar.gz

--- a/2.5-rc/Dockerfile
+++ b/2.5-rc/Dockerfile
@@ -15,7 +15,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.5-dev9
 ENV HAPROXY_URL https://www.haproxy.org/download/2.5/src/devel/haproxy-2.5-dev9.tar.gz

--- a/2.5-rc/alpine/Dockerfile
+++ b/2.5-rc/alpine/Dockerfile
@@ -16,7 +16,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 
 ENV HAPROXY_VERSION 2.5-dev9
 ENV HAPROXY_URL https://www.haproxy.org/download/2.5/src/devel/haproxy-2.5-dev9.tar.gz

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,7 +11,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 {{ ) else ( -}}
 FROM debian:{{ .debian }}
 
@@ -24,7 +27,10 @@ RUN set -eux; \
 		--no-create-home \
 		--system \
 		--uid 99 \
-		haproxy
+		haproxy \
+	; \
+	mkdir /var/lib/haproxy; \
+	chown haproxy:haproxy /var/lib/haproxy
 {{ ) end -}}
 
 ENV HAPROXY_VERSION {{ .version }}


### PR DESCRIPTION
In the v2.4 `Dockerfile` user **haproxy** is added without creating a $HOME directory for it. I may miss something here, but I would like to know why is this user without a home directory? https://github.com/docker-library/haproxy/blob/caa9511cd1ae40248aaf542a2c738d745006cbe6/2.4/Dockerfile#L15

I would use the *haproxy* user's home directory for stats socket, but the dir does not exists, and as 2.4 runs as unprivileged *haproxy* user, I have no permission to create the directory( and I don't want to use `/tmp`).

Example config:
```haproxy
stats socket /var/lib/haproxy/haproxy-stats.sock
```

I can imagine that this change may raise security issues, then reject.
