### PR TITLE
Bump latest to 2.7

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -3,7 +3,8 @@ set -Eeuo pipefail
 
 # https://www.haproxy.org/#last ("LTS" vs "latest")
 declare -A aliases=(
-	[2.6]='lts latest'
+	[2.6]='lts'
+	[2.7]='latest'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Only moving `latest` to `2.7` since `2.6` is still the newest `lts` until the `2.8` release.