### PR TITLE
Specify WORKDIR /var/lib/haproxy

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -100,4 +100,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # no USER for backwards compatibility (to try to avoid breaking existing users)
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.0/alpine/Dockerfile
+++ b/2.0/alpine/Dockerfile
@@ -93,4 +93,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # no USER for backwards compatibility (to try to avoid breaking existing users)
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -100,4 +100,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # no USER for backwards compatibility (to try to avoid breaking existing users)
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -93,4 +93,7 @@ RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # no USER for backwards compatibility (to try to avoid breaking existing users)
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -96,4 +96,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -89,4 +89,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.5/Dockerfile
+++ b/2.5/Dockerfile
@@ -96,4 +96,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.5/alpine/Dockerfile
+++ b/2.5/alpine/Dockerfile
@@ -89,4 +89,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -96,4 +96,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.6/alpine/Dockerfile
+++ b/2.6/alpine/Dockerfile
@@ -89,4 +89,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -96,4 +96,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+WORKDIR /var/lib/haproxy
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -97,6 +97,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
 
+# https://github.com/docker-library/haproxy/issues/200
 WORKDIR /var/lib/haproxy
 
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -90,6 +90,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
 
+# https://github.com/docker-library/haproxy/issues/200
 WORKDIR /var/lib/haproxy
 
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.7/alpine/Dockerfile
+++ b/2.7/alpine/Dockerfile
@@ -89,4 +89,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+WORKDIR /var/lib/haproxy
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -96,4 +96,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+WORKDIR /var/lib/haproxy
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -97,6 +97,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
 
+# https://github.com/docker-library/haproxy/issues/200
 WORKDIR /var/lib/haproxy
 
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.8/alpine/Dockerfile
+++ b/2.8/alpine/Dockerfile
@@ -90,6 +90,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
 
+# https://github.com/docker-library/haproxy/issues/200
 WORKDIR /var/lib/haproxy
 
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/2.8/alpine/Dockerfile
+++ b/2.8/alpine/Dockerfile
@@ -89,4 +89,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER haproxy
+
+WORKDIR /var/lib/haproxy
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -170,4 +170,11 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 {{ ) else ( -}}
 USER haproxy
 {{ ) end -}}
+
+{{ if [ "2.0", "2.2", "2.4", "2.5", "2.6" ] | index(env.version) then ( -}}
+# no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
+{{ ) else ( -}}
+WORKDIR /var/lib/haproxy
+{{ ) end -}}
+
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -174,6 +174,7 @@ USER haproxy
 {{ if [ "2.0", "2.2", "2.4", "2.5", "2.6" ] | index(env.version) then ( -}}
 # no WORKDIR for backwards compatibility (to try to avoid breaking existing users)
 {{ ) else ( -}}
+# https://github.com/docker-library/haproxy/issues/200
 WORKDIR /var/lib/haproxy
 {{ ) end -}}
 


### PR DESCRIPTION
Opted to apply this to 2.7+ only, as the odd-numbered versions are for power-users that are able to deal with some breakage.

-------------------

Resolves docker-library/haproxy#200