### PR TITLE
Update to Debian bookworm

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -77,7 +77,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \
@@ -77,7 +77,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bookworm-slim
+FROM debian:bullseye-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.19
+FROM alpine:3.16
 
 # roughly, https://git.alpinelinux.org/aports/tree/main/haproxy/haproxy.pre-install?h=3.12-stable
 RUN set -eux; \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \
@@ -74,7 +74,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \
@@ -74,7 +74,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \
@@ -74,7 +74,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/2.8/Dockerfile
+++ b/2.8/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \
@@ -74,7 +74,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/2.9/Dockerfile
+++ b/2.9/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \
@@ -74,7 +74,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # roughly, https://salsa.debian.org/haproxy-team/haproxy/-/blob/732b97ae286906dea19ab5744cf9cf97c364ac1d/debian/haproxy.postinst#L5-6
 RUN set -eux; \
@@ -74,7 +74,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -140,7 +140,7 @@ RUN set -eux; \
 	apt-mark auto '.*' > /dev/null; \
 	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { print $(NF-1) }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/versions.json
+++ b/versions.json
@@ -7,8 +7,8 @@
     "version": "2.0.33"
   },
   "2.2": {
-    "alpine": "3.19",
-    "debian": "bookworm-slim",
+    "alpine": "3.16",
+    "debian": "bullseye-slim",
     "sha256": "94b099e0142c3e5689b2a1a4943eafa02a453b342e6527cd108b722f8d0a82f6",
     "url": "https://www.haproxy.org/download/2.2/src/haproxy-2.2.31.tar.gz",
     "version": "2.2.31"

--- a/versions.json
+++ b/versions.json
@@ -8,49 +8,49 @@
   },
   "2.2": {
     "alpine": "3.19",
-    "debian": "bullseye-slim",
+    "debian": "bookworm-slim",
     "sha256": "94b099e0142c3e5689b2a1a4943eafa02a453b342e6527cd108b722f8d0a82f6",
     "url": "https://www.haproxy.org/download/2.2/src/haproxy-2.2.31.tar.gz",
     "version": "2.2.31"
   },
   "2.4": {
     "alpine": "3.19",
-    "debian": "bullseye-slim",
+    "debian": "bookworm-slim",
     "sha256": "decc925111980792f32ecb8778b1105d7d4594880c75d4d973fc85214ad6a953",
     "url": "https://www.haproxy.org/download/2.4/src/haproxy-2.4.24.tar.gz",
     "version": "2.4.24"
   },
   "2.6": {
     "alpine": "3.19",
-    "debian": "bullseye-slim",
+    "debian": "bookworm-slim",
     "sha256": "41f8e1695e92fafdffe39690a68993f1a0f5f7f06931a99e9a153f749ea39cfd",
     "url": "https://www.haproxy.org/download/2.6/src/haproxy-2.6.15.tar.gz",
     "version": "2.6.15"
   },
   "2.7": {
     "alpine": "3.19",
-    "debian": "bullseye-slim",
+    "debian": "bookworm-slim",
     "sha256": "b064c5cd64615899ab39e518ff900b71c6e321d5f883d32dd871c31b372ebbc4",
     "url": "https://www.haproxy.org/download/2.7/src/haproxy-2.7.11.tar.gz",
     "version": "2.7.11"
   },
   "2.8": {
     "alpine": "3.19",
-    "debian": "bullseye-slim",
+    "debian": "bookworm-slim",
     "sha256": "3f5459c5a58e0b343a32eaef7ed5bed9d3fc29d8aa9e14b36c92c969fc2a60d9",
     "url": "https://www.haproxy.org/download/2.8/src/haproxy-2.8.5.tar.gz",
     "version": "2.8.5"
   },
   "2.9": {
     "alpine": "3.19",
-    "debian": "bullseye-slim",
+    "debian": "bookworm-slim",
     "sha256": "fba18acd1a46337fe20ae07c816c2496c8602b80a1bc9ff3768d4caa5fb80eab",
     "url": "https://www.haproxy.org/download/2.9/src/haproxy-2.9.0.tar.gz",
     "version": "2.9.0"
   },
   "3.0": {
     "alpine": "3.19",
-    "debian": "bullseye-slim",
+    "debian": "bookworm-slim",
     "sha256": "47c387d203ab00b5501017691f741375359a161216a84b17e55e48f2e84adc9f",
     "url": "https://www.haproxy.org/download/3.0/src/devel/haproxy-3.0-dev0.tar.gz",
     "version": "3.0-dev0"

--- a/versions.sh
+++ b/versions.sh
@@ -14,11 +14,13 @@ versions=( "${versions[@]%/}" )
 
 defaultDebianSuite='bookworm-slim'
 declare -A debianSuite=(
+	[2.2]='bullseye-slim'
 	[2.0]='buster-slim'
 )
 defaultAlpineVersion='3.19'
 declare -A alpineVersion=(
-	# OpenSSL 3 incompatibilities
+	# OpenSSL 3 incompatibilities (https://github.com/haproxy/haproxy/issues/1276)
+	[2.2]='3.16'
 	[2.0]='3.16'
 )
 

--- a/versions.sh
+++ b/versions.sh
@@ -12,7 +12,7 @@ else
 fi
 versions=( "${versions[@]%/}" )
 
-defaultDebianSuite='bullseye-slim'
+defaultDebianSuite='bookworm-slim'
 declare -A debianSuite=(
 	[2.0]='buster-slim'
 )


### PR DESCRIPTION
Leaving `2.0` on Debian buster: https://github.com/docker-library/haproxy/pull/167